### PR TITLE
Enable right click deny only while space is pressed.

### DIFF
--- a/Dota 2 Legacy Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_default.cfg
+++ b/Dota 2 Legacy Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_default.cfg
@@ -138,3 +138,6 @@ bind F11 "custom_toggle_developer"
 
 //Load the hero binds for the hero toggled currently
 load_current_hero_nomod_binds
+
+// Disable right click deny when space isn't pressed
+dota_force_right_click_attack 0

--- a/Dota 2 Legacy Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_space_pressed.cfg
+++ b/Dota 2 Legacy Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_space_pressed.cfg
@@ -96,3 +96,6 @@ bind "," "say_team [all come bot]"
 
 //Load the hero binds for the hero toggled currently
 load_current_hero_space_binds
+
+// Enable right click deny when space is pressed.
+dota_force_right_click_attack 1

--- a/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_default.cfg
+++ b/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_default.cfg
@@ -138,3 +138,7 @@ bind F11 "custom_toggle_developer"
 
 //Load the hero binds for the hero toggled currently
 load_current_hero_nomod_binds
+
+
+// Disable right click deny when space isn't pressed
+dota_force_right_click_attack 0

--- a/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_space_pressed.cfg
+++ b/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_space_pressed.cfg
@@ -96,3 +96,7 @@ bind "," chatwheel_say 70 //Relax
 
 //Load the hero binds for the hero toggled currently
 load_current_hero_space_binds
+
+
+// Enable right click deny when space is pressed.
+dota_force_right_click_attack 1


### PR DESCRIPTION
A drawback of enabling right click deny is that if you are a ranged hero and want to move towards a location, if there is an allied creep/hero/ward at that position, your hero will try to deny it and if it isn't deniable it will issue an attack on the closest enemy. This is a problem when you are trying to escape and suddenly you start attacking instead of running away.

With this config, right click is enabled only while space is pressed. It has been useful to me, if you guys find it useful too, you can include it in the main config.