### PR TITLE
Right Click Deny toggle (Issue #26, Comment 10)

### DIFF
--- a/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_functions_active.cfg
+++ b/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_functions_active.cfg
@@ -1,11 +1,11 @@
 ////////////////////////////////////////////////////////////
 //Active command section - these are used throughout the other files
 ////////////////////////////////////////////////////////////
- 
+
 
 
 ////////////////////////////////////////////////////////////
-//Core modifier functionality 
+//Core modifier functionality
 ////////////////////////////////////////////////////////////
 
 //Loads the keybinds in the "dota2_keybinds_space_pressed.cfg" file when space is pressed, and reverts to normal when depressed
@@ -46,8 +46,8 @@ alias "quick_cast_toggled_on" "playsound sounds/ui/tutorial_ui_ding_01.vsnd_c;al
 alias "quick_cast_toggled_off" "playsound sounds/ui/ui_upgrade_ability_01.vsnd_c;alias quick_normal_cast_toggle quick_cast_toggled_on;alias load_primary_cast_mode exec dota2_gameplay_mode/dota2_keybinds_toggle_non-quickcast.cfg; alias load_secondary_cast_mode exec dota2_gameplay_mode/dota2_keybinds_toggle_quickcast.cfg;exec dota2_gameplay_mode/dota2_keybinds_default.cfg; say_student Quickcast mode disabled"
 
 //Used for the open mic toggle
-alias "mic_toggle" "openmic" 
-alias "openmic" "voice_vox 1; playsound sounds/ui/tutorial_ui_ding_01.vsnd_c; alias mic_toggle closemic; say_student Open mic enabled" 
+alias "mic_toggle" "openmic"
+alias "openmic" "voice_vox 1; playsound sounds/ui/tutorial_ui_ding_01.vsnd_c; alias mic_toggle closemic; say_student Open mic enabled"
 alias "closemic" "voice_vox 0; playsound sounds/ui/ui_upgrade_ability_01.vsnd_c; alias mic_toggle openmic; say_student Open mic disabled"
 
 //Toggle health segmentation between these values
@@ -115,3 +115,10 @@ alias "bottom_rune" "dota_camera_set_lookatpos 3035 -2350; alias +rune top_rune"
 //Toggle orb autocast
 //(one click button to toggle on every auto-cast ability, this works because no hero has more than 1 ability so it just tries to do it for all of them)
 alias "orb_toggle" "dota_ability_autocast 0; dota_ability_autocast 1; dota_ability_autocast 2; dota_ability_autocast 3; dota_ability_autocast 4;dota_ability_autocast 5"
+
+//Change between right-click deny on, off, space toggled
+alias "rc_deny" "rc_deny_on"
+alias "rc_deny_mode" "rc_deny_off"
+alias "rc_deny_on" "dota_force_right_click_attack 1;alias rc_deny rc_deny_on;alias rc_deny_mode rc_deny_toggle"
+alias "rc_deny_toggle" "toggle dota_force_right_click_attack;alias rc_deny rc_deny_toggle;alias rc_deny_mode rc_deny_off"
+alias "rc_deny_off" "dota_force_right_click_attack 0;alias rc_deny rc_deny_off;alias rc_deny_mode rc_deny_on"

--- a/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_default.cfg
+++ b/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_default.cfg
@@ -88,12 +88,12 @@ bind "ALT" "+keyShift2"
 bind "F7" "quick_normal_cast_toggle"
 
 //Mode toggled (Quick or Normal cast) cast for items
-bind "mouse5" "toggle_enabled_use_item_0"					
-bind "D" "toggle_enabled_use_item_1" 
-bind "F" "toggle_enabled_use_item_2"                    
-bind "X" "toggle_enabled_use_item_3"                     
-bind "C" "toggle_enabled_use_item_4"                   
-bind "V" "toggle_enabled_use_item_5"		
+bind "mouse5" "toggle_enabled_use_item_0"
+bind "D" "toggle_enabled_use_item_1"
+bind "F" "toggle_enabled_use_item_2"
+bind "X" "toggle_enabled_use_item_3"
+bind "C" "toggle_enabled_use_item_4"
+bind "V" "toggle_enabled_use_item_5"
 
 //Mode toggled (Quick or Normal cast) cast for abilities
 bind "Q" "toggle_enabled_use_ability_0"
@@ -140,5 +140,6 @@ bind F11 "custom_toggle_developer"
 load_current_hero_nomod_binds
 
 
-// Disable right click deny when space isn't pressed
-dota_force_right_click_attack 0
+// Enable/Disable right click deny when space isn't pressed, or when u is pressed
+toggle dota_force_right_click_attack
+bindtoggle "u" "dota_force_right_click_attack"

--- a/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_default.cfg
+++ b/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_default.cfg
@@ -30,7 +30,7 @@ bind "0" "+dota_control_group 9"
 bind "TAB" "dota_cycle_selected"
 
 //Learn stats.
-bind "H" "dota_learn_stats"                     
+bind "H" "dota_learn_stats"
 
 //Inspect hero
 bind "I" "inspectheroinworld"
@@ -72,7 +72,7 @@ bind "B" "toggleshoppanel"
 bind "CAPSLOCK" "+voicerecord"
 
 //Go to recent event/ping
-bind "Z" "dota_recent_event;"   
+bind "Z" "dota_recent_event;"
 
 ////////////////////////////////////////////////////////////
 //Custom Shit
@@ -110,7 +110,7 @@ load_primary_cast_mode
 bind "A" "mc_attack; +sixense_left_click; -sixense_left_click"
 
 // Shuffle camera to rune positions while pressing the keys and back to hero on release
-bind "F1" "+rune"  
+bind "F1" "+rune"
 
 //Missing Script and other communications
 //(binds the arrow keys to call missing, not as useful with the chat wheel thing but I prefer it still)
@@ -141,5 +141,8 @@ load_current_hero_nomod_binds
 
 
 // Enable/Disable right click deny when space isn't pressed, or when u is pressed
-toggle dota_force_right_click_attack
-bindtoggle "u" "dota_force_right_click_attack"
+rc_deny
+bind "u" "rc_deny_mode"
+
+// Force right click deny on when o is pressed
+bind "o" "rc_deny_on"

--- a/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_space_pressed.cfg
+++ b/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_space_pressed.cfg
@@ -31,7 +31,7 @@ bind "F3" "dota_courier_burst"
 //Custom Shit
 ////////////////////////////////////////////////////////////
 
-//Keep SPACE as the modifier 
+//Keep SPACE as the modifier
 bind "SPACE" "+keyShift"
 
 //SPACE+1 to jump camera to hero with single key
@@ -58,12 +58,12 @@ load_secondary_cast_mode
 bind "F4" "quick_upgrade_courier"
 
 //Mode toggled (Quick or Normal cast) cast for items
-bind "mouse5" "toggle_enabled_use_item_0"					
-bind "D" "toggle_enabled_use_item_1" 
-bind "F" "toggle_enabled_use_item_2"                    
-bind "X" "toggle_enabled_use_item_3"                     
-bind "C" "toggle_enabled_use_item_4"                   
-bind "V" "toggle_enabled_use_item_5"		
+bind "mouse5" "toggle_enabled_use_item_0"
+bind "D" "toggle_enabled_use_item_1"
+bind "F" "toggle_enabled_use_item_2"
+bind "X" "toggle_enabled_use_item_3"
+bind "C" "toggle_enabled_use_item_4"
+bind "V" "toggle_enabled_use_item_5"
 
 //Mode toggled (Quick or Normal cast) cast for abilities
 bind "Q" "toggle_enabled_use_ability_0"
@@ -75,7 +75,7 @@ bind "R" "toggle_enabled_use_ability_5"
 
 //Toggle orb autocast
 //(one click button to toggle on every auto-cast ability, this works because no hero has more than 1 ability so it just tries to do it for all of them)
-bind "Z" "orb_toggle"  
+bind "Z" "orb_toggle"
 
 //Binds to enable you to communicate with your team with your right side of the keyboard
 bind "U" chatwheel_say 51 //Stack
@@ -98,5 +98,5 @@ bind "," chatwheel_say 70 //Relax
 load_current_hero_space_binds
 
 
-// Enable right click deny when space is pressed.
-dota_force_right_click_attack 1
+// Enable/Disable right click deny when space is pressed.
+toggle dota_force_right_click_attack

--- a/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_space_pressed.cfg
+++ b/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_space_pressed.cfg
@@ -98,5 +98,5 @@ bind "," chatwheel_say 70 //Relax
 load_current_hero_space_binds
 
 
-// Enable/Disable right click deny when space is pressed.
-toggle dota_force_right_click_attack
+// Enable right click deny when space is pressed, and toggle mode is enabled
+rc_deny


### PR DESCRIPTION
Creates a toggle for right click deny that works as specified in Issue #26 Comment 10, toggles from a default of On -> Space Dependent -> Off, bound to "u", with a hotkey "o" to force right-click deny on all the time.