### PR TITLE
Changed netgraph toggle to new netgraph

### DIFF
--- a/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_functions_active.cfg
+++ b/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_functions_active.cfg
@@ -55,8 +55,8 @@ alias "toggle_segments" "toggle dota_health_per_vertical_marker 200 300 400 500;
 
 //Toggle netgraph on and off
 alias "custom_toggle_netgraph" "show_net_graph"
-alias "show_net_graph" "net_graph 1; alias custom_toggle_netgraph hide_net_graph"
-alias "hide_net_graph" "net_graph 0; alias custom_toggle_netgraph show_net_graph"
+alias "show_net_graph" "dota_hud_netgraph 1; alias custom_toggle_netgraph hide_net_graph"
+alias "hide_net_graph" "dota_hud_netgraph 0; alias custom_toggle_netgraph show_net_graph"
 
 //Toggle developer mode on and off
 alias "custom_toggle_developer" "developer_on"


### PR DESCRIPTION
I couldn't find another mention of the old net_graph 1 command, but should one exist, it should be dota_hud_netgraph 1