### PR TITLE
Per Key ability and item quickcast toggles and Neatened files

### DIFF
--- a/Dota 2 Legacy Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/autoexec.cfg
+++ b/Dota 2 Legacy Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/autoexec.cfg
@@ -1,55 +1,54 @@
 echo "================================================"
 echo "===========[AUTOEXEC CONFIG LOADED]============="
 echo "================================================"
-echo "    Loopuleasa's Super Compact Layout v4.3"
-echo "             Updated 04/11/2014"
+echo "    Loopuleasa's Super Compact Layout v4.3      "
+echo "             Updated 04/11/2014                 "
 echo "================================================"
 
 
 
 ////////////////////////////////////////////////////////////
-//Basic autoexec functions
+//  Basic autoexec functions                              //
 ////////////////////////////////////////////////////////////
 
-//Enables console
-//You can also enable console by adding the "-console" parameter in the launch options, but that opens a console window on game open which is annoying
+//  Enables console
+//  You can also enable console by adding the "-console" parameter in the launch options, but that opens a console window on game open which is annoying
 con_enable "1"
-developer "0" 				
+developer "0"
 contimes 5
 
-//Play a confirmation sound that the autoexec loaded
+//  Play a confirmation sound that the autoexec loaded
 playuisound DOTA_Item.Hand_Of_Midas
 
 
 ////////////////////////////////////////////////////////////
-//Load the game settings
+//  Load the game settings                                //
 ////////////////////////////////////////////////////////////
 
-//Load the tech settings from dota2_settings_tech.cfg
+//   Load the tech settings from dota2_settings_tech.cfg
 execifexists dota2_gameplay_mode/dota2_settings_tech.cfg
 
-//Load the game settings from "dota2_settings_game.cfg"
+//  Load the game settings from "dota2_settings_game.cfg"
 execifexists dota2_gameplay_mode/dota2_settings_game.cfg
 
 
-
 ////////////////////////////////////////////////////////////
-//Load the custom functions
+//  Load the custom functions                             //
 ////////////////////////////////////////////////////////////
 
-//Sets up the active functions defined from the external file
+//  Sets up the active functions defined from the external file
 execifexists dota2_gameplay_mode/dota2_functions_active.cfg
 
 
 ////////////////////////////////////////////////////////////
-//Load default Keybinds
+//  Load default Keybinds                                 //
 ////////////////////////////////////////////////////////////
 
-//Load the regular keybinds from the external "dota2_keybinds_default.cfg" file
+//  Load the regular keybinds from the external "dota2_keybinds_default.cfg" file
 execifexists dota2_gameplay_mode/dota2_keybinds_default.cfg
 
-//This line initialises the initial cast mode state to quick cast
+//  This line initialises the initial cast mode state to quick cast
 quick_normal_cast_toggle
 
-//This line rebinds ALT (Ping is now on Tilde) - this is needed for ALT+ keyboard layout to work and not conflict
-dota_remap_alt_key "`" 
+//  This line rebinds ALT (Ping is now on Tilde) - this is needed for ALT+ keyboard layout to work and not conflict
+dota_remap_alt_key "`"

--- a/Dota 2 Legacy Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_functions_active.cfg
+++ b/Dota 2 Legacy Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_functions_active.cfg
@@ -1,25 +1,22 @@
-////////////////////////////////////////////////////////////
-//Active command section - these are used throughout the other files
-////////////////////////////////////////////////////////////
-
-
+////////////////////////////////////////////////////////////////////////////
+//  Active command section - these are used throughout the other files    //
+////////////////////////////////////////////////////////////////////////////
 
 ////////////////////////////////////////////////////////////
-//Core modifier functionality
+//  Core modifier functionality                           //
 ////////////////////////////////////////////////////////////
 
-//Loads the keybinds in the "dota2_keybinds_space_pressed.cfg" file when space is pressed, and reverts to normal when depressed
+//  Loads the keybinds in the "dota2_keybinds_space_pressed.cfg" file when space is pressed, and reverts to normal when depressed
 alias +keyShift "execifexists dota2_gameplay_mode/dota2_keybinds_space_pressed.cfg"
 alias -keyShift "execifexists dota2_gameplay_mode/dota2_keybinds_default.cfg"
 
-//Loads the keybinds in the "dota2_keybinds_alt_pressed.cfg" file when ALT is pressed, and reverts to normal when depressed
+//  Loads the keybinds in the "dota2_keybinds_alt_pressed.cfg" file when ALT is pressed, and reverts to normal when depressed
 alias +keyShift2 "execifexists dota2_gameplay_mode/dota2_keybinds_alt_pressed.cfg"
 alias -keyShift2 "execifexists dota2_gameplay_mode/dota2_keybinds_default.cfg"
 
 
-
 ////////////////////////////////////////////////////////////
-//Hero custom config switches
+//  Hero custom config switches                           //
 ////////////////////////////////////////////////////////////
 
 execifexists "dota2_hero_custom_configs/setup_hero_mode.cfg"
@@ -27,62 +24,69 @@ execifexists "dota2_hero_custom_configs/setup_hero_mode.cfg"
 
 
 ////////////////////////////////////////////////////////////
-//Toggle functionalities
+//  Toggle functionalities                                //
 ////////////////////////////////////////////////////////////
 
-//Auto attack toggle (must be first configured here to work properly)
+//  Auto attack toggle (must be first configured here to work properly)
 alias "auto_attack_toggle" "auto_attack_toggle_on"
 alias "auto_attack_toggle_on" "playuisound DOTA_Item.MedallionOfCourage.Activate;dota_player_units_auto_attack 1; dota_player_units_auto_attack_after_spell 1; alias auto_attack_toggle auto_attack_toggle_off;echo Auto-attack disabled."
 alias "auto_attack_toggle_off" "playuisound DOTA_Item.MagicStick.Activate;dota_player_units_auto_attack 0; dota_player_units_auto_attack_after_spell 0; alias auto_attack_toggle auto_attack_toggle_on;echo Auto-attack enabled."
 
-//Auto select summoned units toggle
+//  Change between right-click deny on, off, space toggled
+alias "rc_deny_mode" "rc_deny_toggle"
+alias "rc_deny_space" "rc_deny_on"
+alias "rc_deny_on" "dota_force_right_click_attack 1;alias rc_deny_space null;alias rc_deny_mode rc_deny_toggle;say_student RC-Deny On"
+alias "rc_deny_toggle" "dota_force_right_click_attack 0; alias rc_deny_space rc_deny_switch;alias rc_deny_mode rc_deny_off;say_student RC-Deny Space"
+alias "rc_deny_off" "dota_force_right_click_attack 0;alias rc_deny_space null;alias rc_deny_mode rc_deny_on;say_student RC-Deny Off"
+alias "rc_deny_switch" "toggle dota_force_right_click_attack"
+
+//  Auto select summoned units toggle
 alias "auto_select_summoned_toggle" "auto_select_summoned_toggle_off"
 alias "auto_select_summoned_toggle_on" "playuisound DOTA_Item.Manta.Activate;dota_player_add_summoned_to_selection 1; alias auto_select_summoned_toggle auto_select_summoned_toggle_off;echo Auto select summoned units disabled."
 alias "auto_select_summoned_toggle_off" "playuisound DOTA_Item.MagicStick.Activate;dota_player_add_summoned_to_selection 0; alias auto_select_summoned_toggle auto_select_summoned_toggle_on;echo Auto select summoned units enabled."
 
-//Quick or Normal cast mode toggle for items and abilities
+//  Quick or Normal cast mode toggle for items and abilities
 alias "quick_normal_cast_toggle" "quick_cast_toggled_on"
 alias "quick_cast_toggled_on" "playuisound DOTA_Item.ForceStaff.Activate;alias quick_normal_cast_toggle quick_cast_toggled_off;alias load_primary_cast_mode execifexists dota2_gameplay_mode/dota2_keybinds_quick_mode_toggled.cfg; alias load_secondary_cast_mode execifexists dota2_gameplay_mode/dota2_keybinds_normal_mode_toggled.cfg;execifexists dota2_gameplay_mode/dota2_keybinds_default.cfg;echo Quick Cast Mode enabled"
 alias "quick_cast_toggled_off" "playuisound DOTA_Item.ObserverWard.Activate;alias quick_normal_cast_toggle quick_cast_toggled_on;alias load_primary_cast_mode execifexists dota2_gameplay_mode/dota2_keybinds_normal_mode_toggled.cfg; alias load_secondary_cast_mode execifexists dota2_gameplay_mode/dota2_keybinds_quick_mode_toggled.cfg;execifexists dota2_gameplay_mode/dota2_keybinds_default.cfg;echo Normal Cast Mode enabled"
 
-//Used for the open mic toggle
+//  Used for the open mic toggle
 alias "mic_toggle" "openmic"
 alias "openmic" "voice_vox 1; alias mic_toggle closemic;"
 alias "closemic" "voice_vox 0; alias mic_toggle openmic;"
 
-//Toggle health segmentation between these values
+//  Toggle health segmentation between these values
 alias "toggle_segments" "toggle dota_health_per_vertical_marker 200 300 400 500; playuisound DOTA_Item.Necronomicon.Bow"
 
-//Toggle netgraph on and off
+//  Toggle netgraph on and off
 alias "custom_toggle_netgraph" "show_net_graph"
 alias "show_net_graph" "net_graph 1; alias custom_toggle_netgraph hide_net_graph"
 alias "hide_net_graph" "net_graph 0; alias custom_toggle_netgraph show_net_graph"
 
-//Toggle developer mode on and off
+//  Toggle developer mode on and off
 alias "custom_toggle_developer" "developer_on"
 alias "developer_on" "developer 1; echo Debug output enabled.; alias custom_toggle_developer developer_off"
 alias "developer_off" "developer 0; echo Debug output disabled.; alias custom_toggle_developer developer_on"
 
 
-
 ////////////////////////////////////////////////////////////
-//Custom shit
+//  Scripts                                               //
 ////////////////////////////////////////////////////////////
 
-//UPGRADE COURIER (Good for those moments when the courier is one flying hit away from dying and you don't have time to browse the shop)
+//  UPGRADE COURIER (Good for those moments when the courier is one flying hit away from dying and you don't have time to browse the shop)
 alias "quick_upgrade_courier" "dota_shop_force_hotkeys 1;toggleshoppanel;shop_nav_to_tab 0;shop_select_itemrow 8;toggleshoppanel"
 
-//A faster courier deliver items (just like the normal one, but it solves a bug that the one from volvo has), with team say
-//It solves this problem: http://www.twitch.tv/2c2c/b/564756824
-//It has one problem: if someone is using courier, it stops, so it can only be used when it is in fountain
-//It also selects the hero on press, cannot change that
+//  A faster courier deliver items (just like the normal one, but it solves a bug that the one from volvo has), with team say
+//  It solves this problem: http://www.twitch.tv/2c2c/b/564756824
+//  It has one problem: if someone is using courier, it stops, so it can only be used when it is in fountain
+//  It also selects the hero on press, cannot change that
 alias "swift_courier_deliver" "dota_select_courier;stash_grab_all;dota_courier_deliver;dota_courier_burst;dota_ability_quickcast 4;+dota_camera_follow;-dota_camera_follow;say_team [requesting courier]"
 
-//Jump camera to hero with single key
+//  Jump camera to hero with single key
 alias "+tohero" "+dota_camera_follow;-dota_camera_follow;+dota_camera_follow"
 alias "-tohero" "-dota_camera_follow"
 
-//Jump camera to to control group with single key
+//  Jump camera to to control group with single key
 alias "+togroup1" "+dota_control_group 1;-dota_control_group 1;+dota_control_group 1"
 alias "-togroup1" "-dota_control_group 1"
 alias "+togroup2" "+dota_control_group 2;-dota_control_group 2;+dota_control_group 2"
@@ -102,24 +106,16 @@ alias "-togroup8" "-dota_control_group 8"
 alias "+togroup9" "+dota_control_group 9;-dota_control_group 9;+dota_control_group 9"
 alias "-togroup9" "-dota_control_group 9"
 
-//Camera grip custom key
+//  Camera grip custom key
 alias "+cameraControl" "+cameragrip;+sixense_left_click";
 alias "-cameraControl" "-cameragrip;-sixense_left_click";
 
-// Shuffle camera to rune positions while pressing the keys and back to hero on release
+//  Shuffle camera to rune positions while pressing the keys and back to hero on release
 alias "+rune" "top_rune"
 alias "-rune" "dota_recent_event; dota_recent_event; +dota_camera_follow"
 alias "top_rune" "dota_camera_set_lookatpos -2273 1800; alias +rune bottom_rune"
 alias "bottom_rune" "dota_camera_set_lookatpos 3035 -2350; alias +rune top_rune"
 
-//Toggle orb autocast
-//(one click button to toggle on every auto-cast ability, this works because no hero has more than 1 ability so it just tries to do it for all of them)
+//  Toggle orb autocast
+//  (one click button to toggle on every auto-cast ability, this works because no hero has more than 1 ability so it just tries to do it for all of them)
 alias "orb_toggle" "dota_ability_autocast 0; dota_ability_autocast 1; dota_ability_autocast 2; dota_ability_autocast 3; dota_ability_autocast 4;dota_ability_autocast 5"
-
-//Change between right-click deny on, off, space toggled
-alias "rc_deny_mode" "rc_deny_toggle"
-alias "rc_deny_space" "rc_deny_on"
-alias "rc_deny_on" "dota_force_right_click_attack 1;alias rc_deny_space null;alias rc_deny_mode rc_deny_toggle;say_student RC-Deny On"
-alias "rc_deny_toggle" "dota_force_right_click_attack 0; alias rc_deny_space rc_deny_switch;alias rc_deny_mode rc_deny_off;say_student RC-Deny Space"
-alias "rc_deny_off" "dota_force_right_click_attack 0;alias rc_deny_space null;alias rc_deny_mode rc_deny_on;say_student RC-Deny Off"
-alias "rc_deny_switch" "toggle dota_force_right_click_attack"

--- a/Dota 2 Legacy Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_functions_active.cfg
+++ b/Dota 2 Legacy Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_functions_active.cfg
@@ -14,6 +14,9 @@ alias -keyShift "execifexists dota2_gameplay_mode/dota2_keybinds_default.cfg"
 alias +keyShift2 "execifexists dota2_gameplay_mode/dota2_keybinds_alt_pressed.cfg"
 alias -keyShift2 "execifexists dota2_gameplay_mode/dota2_keybinds_default.cfg"
 
++alias +keyShift3 "exec dota2_gameplay_mode/dota2_keybinds_alt_space_pressed.cfg"
++alias -keyShift3 "exec dota2_gameplay_mode/dota2_keybinds_default.cfg"
+
 
 ////////////////////////////////////////////////////////////
 //  Hero custom config switches                           //
@@ -47,8 +50,11 @@ alias "auto_select_summoned_toggle_off" "playuisound DOTA_Item.MagicStick.Activa
 
 //  Quick or Normal cast mode toggle for items and abilities
 alias "quick_normal_cast_toggle" "quick_cast_toggled_on"
-alias "quick_cast_toggled_on" "playuisound DOTA_Item.ForceStaff.Activate;alias quick_normal_cast_toggle quick_cast_toggled_off;alias load_primary_cast_mode execifexists dota2_gameplay_mode/dota2_keybinds_quick_mode_toggled.cfg; alias load_secondary_cast_mode execifexists dota2_gameplay_mode/dota2_keybinds_normal_mode_toggled.cfg;execifexists dota2_gameplay_mode/dota2_keybinds_default.cfg;echo Quick Cast Mode enabled"
-alias "quick_cast_toggled_off" "playuisound DOTA_Item.ObserverWard.Activate;alias quick_normal_cast_toggle quick_cast_toggled_on;alias load_primary_cast_mode execifexists dota2_gameplay_mode/dota2_keybinds_normal_mode_toggled.cfg; alias load_secondary_cast_mode execifexists dota2_gameplay_mode/dota2_keybinds_quick_mode_toggled.cfg;execifexists dota2_gameplay_mode/dota2_keybinds_default.cfg;echo Normal Cast Mode enabled"
+alias "quick_cast_toggled_on" "playuisound DOTA_Item.ForceStaff.Activate;alias quick_normal_cast_toggle quick_cast_toggled_off;execifexists dota2_gameplay_mode/dota2_keybinds_quick_mode_toggled.cfg"
+alias "quick_cast_toggled_off" "playuisound DOTA_Item.ObserverWard.Activate;alias quick_normal_cast_toggle quick_cast_toggled_on;execifexists dota2_gameplay_mode/dota2_keybinds_normal_mode_toggled.cfg"
+
++//Individual Ability/Skill Quick/Normal Cast Toggle config
++exec dota2_gameplay_mode/dota2_keybinds_togglekeys.cfg
 
 //  Used for the open mic toggle
 alias "mic_toggle" "openmic"

--- a/Dota 2 Legacy Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_functions_active.cfg
+++ b/Dota 2 Legacy Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_functions_active.cfg
@@ -80,7 +80,7 @@ alias "developer_off" "developer 0; echo Debug output disabled.; alias custom_to
 ////////////////////////////////////////////////////////////
 
 //  UPGRADE COURIER (Good for those moments when the courier is one flying hit away from dying and you don't have time to browse the shop)
-alias "quick_upgrade_courier" "dota_shop_force_hotkeys 1;toggleshoppanel;shop_nav_to_tab 0;shop_select_itemrow 8;toggleshoppanel"
+alias "quick_upgrade_courier" "dota_shop_force_hotkeys 1;toggleshoppanel;shop_nav_to_tab 0;shop_select_itemrow 9;toggleshoppanel"
 
 //  A faster courier deliver items (just like the normal one, but it solves a bug that the one from volvo has), with team say
 //  It solves this problem: http://www.twitch.tv/2c2c/b/564756824

--- a/Dota 2 Legacy Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_functions_active.cfg
+++ b/Dota 2 Legacy Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_functions_active.cfg
@@ -14,8 +14,9 @@ alias -keyShift "execifexists dota2_gameplay_mode/dota2_keybinds_default.cfg"
 alias +keyShift2 "execifexists dota2_gameplay_mode/dota2_keybinds_alt_pressed.cfg"
 alias -keyShift2 "execifexists dota2_gameplay_mode/dota2_keybinds_default.cfg"
 
-+alias +keyShift3 "exec dota2_gameplay_mode/dota2_keybinds_alt_space_pressed.cfg"
-+alias -keyShift3 "exec dota2_gameplay_mode/dota2_keybinds_default.cfg"
+//  Loads the keybinds in the "dota2_keybinds_alt_space_pressed.cfg" file when ALT+Space is pressed, and reverts to normal when depressed
+alias +keyShift3 "exec dota2_gameplay_mode/dota2_keybinds_alt_space_pressed.cfg"
+alias -keyShift3 "exec dota2_gameplay_mode/dota2_keybinds_default.cfg"
 
 
 ////////////////////////////////////////////////////////////
@@ -23,7 +24,6 @@ alias -keyShift2 "execifexists dota2_gameplay_mode/dota2_keybinds_default.cfg"
 ////////////////////////////////////////////////////////////
 
 execifexists "dota2_hero_custom_configs/setup_hero_mode.cfg"
-
 
 
 ////////////////////////////////////////////////////////////
@@ -53,8 +53,8 @@ alias "quick_normal_cast_toggle" "quick_cast_toggled_on"
 alias "quick_cast_toggled_on" "playuisound DOTA_Item.ForceStaff.Activate;alias quick_normal_cast_toggle quick_cast_toggled_off;execifexists dota2_gameplay_mode/dota2_keybinds_quick_mode_toggled.cfg"
 alias "quick_cast_toggled_off" "playuisound DOTA_Item.ObserverWard.Activate;alias quick_normal_cast_toggle quick_cast_toggled_on;execifexists dota2_gameplay_mode/dota2_keybinds_normal_mode_toggled.cfg"
 
-+//Individual Ability/Skill Quick/Normal Cast Toggle config
-+exec dota2_gameplay_mode/dota2_keybinds_togglekeys.cfg
+//Individual Ability/Skill Quick/Normal Cast Toggle config
+exec dota2_gameplay_mode/dota2_keybinds_togglekeys.cfg
 
 //  Used for the open mic toggle
 alias "mic_toggle" "openmic"

--- a/Dota 2 Legacy Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_alt_pressed.cfg
+++ b/Dota 2 Legacy Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_alt_pressed.cfg
@@ -12,6 +12,9 @@ unbindall
 //  Keep ALT as the modifier
 bind "ALT" "+keyShift2"
 
++//Set ALT+SPACE to be a modifier
++bind "SPACE" "+keyShift3"
+
 
 ////////////////////////////////////////////////////////////
 //  Binds                                                 //

--- a/Dota 2 Legacy Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_alt_pressed.cfg
+++ b/Dota 2 Legacy Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_alt_pressed.cfg
@@ -12,8 +12,8 @@ unbindall
 //  Keep ALT as the modifier
 bind "ALT" "+keyShift2"
 
-+//Set ALT+SPACE to be a modifier
-+bind "SPACE" "+keyShift3"
+//  Set ALT+SPACE to be a modifier
+bind "SPACE" "+keyShift3"
 
 
 ////////////////////////////////////////////////////////////
@@ -48,7 +48,7 @@ bind "Z" "toggle_segments"
 //  Select all units
 bind "1" "dota_select_all"
 
-// Select all other units
+//  Select all other units
 bind "2" "dota_select_all_others"
 
 //  Key to disable/enable open mic

--- a/Dota 2 Legacy Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_alt_pressed.cfg
+++ b/Dota 2 Legacy Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_alt_pressed.cfg
@@ -1,19 +1,31 @@
 ////////////////////////////////////////////////////////////////////////////
-//ALT  is pressed, shifting keyboard functions
+//  ALT  is pressed, shifting keyboard functions                          //
 ////////////////////////////////////////////////////////////////////////////
 
-//Remove all leftover keybinds
+////////////////////////////////////////////////////////////
+//  Core Modifier Functionality                           //
+////////////////////////////////////////////////////////////
+
+//  Remove all leftover keybinds
 unbindall
 
-//ALT to self cast for items
-bind "mouse5" "dota_item_execute 0;dota_item_execute 0"					
-bind "D" "dota_item_execute 1;dota_item_execute 1" 
-bind "F" "dota_item_execute 2;dota_item_execute 2"                    
-bind "X" "dota_item_execute 3;dota_item_execute 3"                     
-bind "C" "dota_item_execute 4;dota_item_execute 4"                   
+//  Keep ALT as the modifier
+bind "ALT" "+keyShift2"
+
+
+////////////////////////////////////////////////////////////
+//  Binds                                                 //
+////////////////////////////////////////////////////////////
+
+//  ALT to self cast for items
+bind "mouse5" "dota_item_execute 0;dota_item_execute 0"
+bind "D" "dota_item_execute 1;dota_item_execute 1"
+bind "F" "dota_item_execute 2;dota_item_execute 2"
+bind "X" "dota_item_execute 3;dota_item_execute 3"
+bind "C" "dota_item_execute 4;dota_item_execute 4"
 bind "V" "dota_item_execute 5;dota_item_execute 5"
 
-//ALT to self cast for abilities
+//  ALT to self cast for abilities
 bind "Q" "dota_ability_execute 0;dota_ability_execute 0"
 bind "W" "dota_ability_execute 1;dota_ability_execute 1"
 bind "E" "dota_ability_execute 2;dota_ability_execute 2"
@@ -21,49 +33,46 @@ bind "T" "dota_ability_execute 3;dota_ability_execute 3"
 bind "G" "dota_ability_execute 4;dota_ability_execute 4"
 bind "R" "dota_ability_execute 5;dota_ability_execute 5"
 
-//Auto-attack toggle (Custom command)
+//  Auto-attack toggle (Custom command)
 bind "S" "auto_attack_toggle"
 
-//Attack
+//  Attack
 bind "A" "mc_attack"
 
-//Toggle health segmetnation between some values
+//  Toggle health segmentation between some values
 bind "Z" "toggle_segments"
 
-//Select all other units
-bind "1" "dota_select_all" 
+//  Select all units
+bind "1" "dota_select_all"
 
-//Select all units
-bind "2" "dota_select_all_others" 
+// Select all other units
+bind "2" "dota_select_all_others"
 
-
-////////////////////////////////////////////////////////////
-//Custom Shit
-////////////////////////////////////////////////////////////
-
-//Keep ALT as the modifier 
-bind "ALT" "+keyShift2"
-
-//Key to disable/enable open mic
+//  Key to disable/enable open mic
 bind CAPSLOCK mic_toggle
 
-//Jump camera to fountains
+
+////////////////////////////////////////////////////////////
+//  Scripts                                               //
+////////////////////////////////////////////////////////////
+
+//  Jump camera to fountains
 bind "F1" "dota_camera_set_lookatpos -6989 -6553"
 bind "F2" "dota_camera_set_lookatpos 6976 6353"
 
-//A faster courier deliver items (just like the normal one, but it solves a bug that the one from volvo has), with team say
-//It solves this problem: http://www.twitch.tv/2c2c/b/564756824
-//It has one problem: if someone is using courier, it stops, so it can only be used when it is in fountain
-//It also selects the hero on press, cannot change that
+//  A faster courier deliver items (just like the normal one, but it solves a bug that the one from volvo has), with team say
+//  It solves this problem: http://www.twitch.tv/2c2c/b/564756824
+//  It has one problem: if someone is using courier, it stops, so it can only be used when it is in fountain
+//  It also selects the hero on press, cannot change that
 bind "F3" "swift_courier_deliver"
 
-//Toogle to enable disable auto select summoned units
+//  Toogle to enable disable auto select summoned units
 bind "F4" "auto_select_summoned_toggle"
 
 
 ////////////////////////////////////////////////////////////
-//Custom Hero Mode binds
+//  Custom Hero Mode binds                                //
 ////////////////////////////////////////////////////////////
 
-//Load the hero binds for the hero toggled currently
+//  Load the hero binds for the hero toggled currently
 load_current_hero_alt_binds

--- a/Dota 2 Legacy Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_alt_space_pressed.cfg
+++ b/Dota 2 Legacy Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_alt_space_pressed.cfg
@@ -1,0 +1,34 @@
+////////////////////////////////////////////////////////////////////////////
+//  Alt + Space is pressed, shifting keyboard functions                   //
+////////////////////////////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////
+//  Core modifier functionality                           //
+////////////////////////////////////////////////////////////
+
+//  Remove all leftover keybinds
+unbindall
+
+bind "ALT" "+keyshift3"
+bind "SPACE" "+keyshift3"
+
+
+////////////////////////////////////////////////////////////
+//  Custom Binds                                          //
+////////////////////////////////////////////////////////////
+
+//  Toggle Quick-Cast / Normal-Cast per item
+bind "mouse5" "toggle_cast_type_item_0"
+bind "D" "toggle_cast_type_item_1"
+bind "F" "toggle_cast_type_item_2"
+bind "X" "toggle_cast_type_item_3"
+bind "C" "toggle_cast_type_item_4"
+bind "V" "toggle_cast_type_item_5"
+
+//  Toggle Quick-Cast / Normal-Cast per ability
+bind "Q" "toggle_cast_type_ability_0"
+bind "W" "toggle_cast_type_ability_1"
+bind "E" "toggle_cast_type_ability_2"
+bind "T" "toggle_cast_type_ability_3"
+bind "G" "toggle_cast_type_ability_4"
+bind "R" "toggle_cast_type_ability_5"

--- a/Dota 2 Legacy Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_default.cfg
+++ b/Dota 2 Legacy Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_default.cfg
@@ -15,9 +15,6 @@ bind "SPACE" "+keyShift"
 //  Make ALT be a modifier key
 bind "ALT" "+keyShift2"
 
-//  Load the primary cast mode keys for abilities and items
-load_primary_cast_mode
-
 
 ////////////////////////////////////////////////////////////
 //  Fixes                                                 //
@@ -36,19 +33,19 @@ load_primary_cast_mode
 
 //  Mode toggled (Quick or Normal cast) cast for items
 bind "mouse5" "toggle_enabled_use_item_0"
-bind "D" "toggle_enabled_use_item_1"
-bind "F" "toggle_enabled_use_item_2"
-bind "X" "toggle_enabled_use_item_3"
-bind "C" "toggle_enabled_use_item_4"
-bind "V" "toggle_enabled_use_item_5"
+bind "D" "enabled_use_item_1"
+bind "F" "enabled_use_item_2"
+bind "X" "enabled_use_item_3"
+bind "C" "enabled_use_item_4"
+bind "V" "enabled_use_item_5"
 
 //  Mode toggled (Quick or Normal cast) cast for abilities
-bind "Q" "toggle_enabled_use_ability_0"
-bind "W" "toggle_enabled_use_ability_1"
-bind "E" "toggle_enabled_use_ability_2"
-bind "T" "toggle_enabled_use_ability_3"
-bind "G" "toggle_enabled_use_ability_4"
-bind "R" "toggle_enabled_use_ability_5"
+bind "Q" "enabled_use_ability_0"
+bind "W" "enabled_use_ability_1"
+bind "E" "enabled_use_ability_2"
+bind "T" "enabled_use_ability_3"
+bind "G" "enabled_use_ability_4"
+bind "R" "enabled_use_ability_5"
 
 //  Show the console
 bind "\" "toggleconsole"

--- a/Dota 2 Legacy Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_default.cfg
+++ b/Dota 2 Legacy Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_default.cfg
@@ -1,23 +1,77 @@
 ////////////////////////////////////////////////////////////////////////////
-//Reverting to default keyboard commands
+//  Reverting to default keyboard commands                                //
 ////////////////////////////////////////////////////////////////////////////
 
-//Remove all leftover keybinds
+////////////////////////////////////////////////////////////
+//  Core Modifier Functionality                           //
+////////////////////////////////////////////////////////////
+
+//  Remove all leftover keybinds
 unbindall
 
-//Fix an issue with Chat Wheel
+//  Make SPACE be a modifier key
+bind "SPACE" "+keyShift"
+
+//  Make ALT be a modifier key
+bind "ALT" "+keyShift2"
+
+//  Load the primary cast mode keys for abilities and items
+load_primary_cast_mode
+
+
+////////////////////////////////////////////////////////////
+//  Fixes                                                 //
+////////////////////////////////////////////////////////////
+
+//  Fix an issue with Chat Wheel
 -chatwheel
 
-//Fix an issue with Score Screen
+//  Fix an issue with Score Screen
 -showscores
 
-//Show the console
+
+////////////////////////////////////////////////////////////
+//  Binds                                                 //
+////////////////////////////////////////////////////////////
+
+//  Mode toggled (Quick or Normal cast) cast for items
+bind "mouse5" "toggle_enabled_use_item_0"
+bind "D" "toggle_enabled_use_item_1"
+bind "F" "toggle_enabled_use_item_2"
+bind "X" "toggle_enabled_use_item_3"
+bind "C" "toggle_enabled_use_item_4"
+bind "V" "toggle_enabled_use_item_5"
+
+//  Mode toggled (Quick or Normal cast) cast for abilities
+bind "Q" "toggle_enabled_use_ability_0"
+bind "W" "toggle_enabled_use_ability_1"
+bind "E" "toggle_enabled_use_ability_2"
+bind "T" "toggle_enabled_use_ability_3"
+bind "G" "toggle_enabled_use_ability_4"
+bind "R" "toggle_enabled_use_ability_5"
+
+//  Show the console
 bind "\" "toggleconsole"
 
-//Select hero
+//  Select hero
 bind "1" +dota_camera_follow
 
-//The micromanagement section
+//  Inspect hero
+bind "I" "inspectheroinworld"
+
+//  Stop key
+bind "S" "dota_stop"
+
+//  A for attack move, instead of A + Click
+bind "A" "toggle_enabled_attack"
+
+//  Enter	 the mode to learn an ability
+bind "Y" dota_ability_learn_mode
+
+//  Learn stats.
+bind "H" "dota_learn_stats"
+
+//  The micromanagement section
 bind "2" "+dota_control_group 1"
 bind "3" "+dota_control_group 2"
 bind "4" "+dota_control_group 3"
@@ -29,91 +83,37 @@ bind "9" "+dota_control_group 8"
 bind "0" "+dota_control_group 9"
 bind "TAB" "dota_cycle_selected"
 
-//Learn stats.
-bind "H" "dota_learn_stats"
+// Enable/Disable right click deny when space isn't pressed, or when u is pressed
+rc_deny_space
+bind "u" "rc_deny_mode"
 
-//Inspect hero
-bind "I" "inspectheroinworld"
+// Force right click deny on when o is pressed
+bind "o" "rc_deny_on"
 
-//Stop key
-bind "S" "dota_stop"
+//  Shop
+bind "B" "toggleshoppanel"
 
-//Camera movements
+//  Voice chat
+bind "CAPSLOCK" "+voicerecord"
+
+//  Go to recent event/ping
+bind "Z" "dota_recent_event;"
+
+//  Camera grip custom key
+bind "KP_5" "+cameraControl";
+
+//  Camera movements
 bind "KP_2" "+back"
 bind "KP_4" "+moveleft"
 bind "KP_6" "+moveright"
 bind "KP_8" "+forward"
 
-//Chat
+//  Chat
 bind "KP_ENTER" "say"
 bind "ENTER" "say"
 
-//Action items or taunts
-bind "[" "use_item_client player_loadout action_item"
-bind "]" "use_item_client current_hero taunt"
-
-//Function keys
-bind "F2" "dota_select_courier"
-bind "F3" "dota_courier_deliver"
-bind "F4" "dota_purchase_quickbuy"
-bind "F5" "gameui_activate"
-bind "F6" "dota_toggle_combatlog"
-bind "F8" "exec autoexec.cfg;con_filter_enable 0;"
-bind "F9" "dota_pause"
-bind "F12" "jpeg"
-
-//Enter	 the mode to learn an ability
-bind "Y" dota_ability_learn_mode
-
-//Shop
-bind "B" "toggleshoppanel"
-
-//Voice chat
-bind "CAPSLOCK" "+voicerecord"
-
-//Go to recent event/ping
-bind "Z" "dota_recent_event;"
-
-////////////////////////////////////////////////////////////
-//Custom Shit
-////////////////////////////////////////////////////////////
-
-//Make SPACE be a modifier key
-bind "SPACE" "+keyShift"
-
-//Make ALT be a modifier key
-bind "ALT" "+keyShift2"
-
-//Bind F7 as the quick/normal cast toggle switch
-bind "F7" "quick_normal_cast_toggle"
-
-//Mode toggled (Quick or Normal cast) cast for items
-bind "mouse5" "toggle_enabled_use_item_0"
-bind "D" "toggle_enabled_use_item_1"
-bind "F" "toggle_enabled_use_item_2"
-bind "X" "toggle_enabled_use_item_3"
-bind "C" "toggle_enabled_use_item_4"
-bind "V" "toggle_enabled_use_item_5"
-
-//Mode toggled (Quick or Normal cast) cast for abilities
-bind "Q" "toggle_enabled_use_ability_0"
-bind "W" "toggle_enabled_use_ability_1"
-bind "E" "toggle_enabled_use_ability_2"
-bind "T" "toggle_enabled_use_ability_3"
-bind "G" "toggle_enabled_use_ability_4"
-bind "R" "toggle_enabled_use_ability_5"
-
-//Load the primary cast mode keys for abilities and items
-load_primary_cast_mode
-
-//A for attack move, instead of A + Click
-bind "A" "toggle_enabled_attack"
-
-// Shuffle camera to rune positions while pressing the keys and back to hero on release
-bind "F1" "+rune"
-
-//Missing Script and other communications
-//(binds the arrow keys to call missing, not as useful with the chat wheel thing but I prefer it still)
+//  Missing Script and other communications
+//  (binds the arrow keys to call missing, not as useful with the chat wheel thing but I prefer it still)
 bind "J" "say_team [miss top]"
 bind "K" "say_team [miss mid]"
 bind "L" "say_team [miss bottom]"
@@ -121,27 +121,41 @@ bind "M" "say_team [returned]"
 bind "N" "say_team [fall back]"
 bind "," "say_team [davai]"
 
-//Camera grip custom key
-bind "KP_5" "+cameraControl";
+//  Action items or taunts
+bind "[" "use_item_client player_loadout action_item"
+bind "]" "use_item_client current_hero taunt"
 
-// Bind a key to enable/disable the net graph
+
+//  Function keys
+////////////////////////////////////////////
+
+//  Shuffle camera to rune positions while pressing the keys and back to hero on release
+bind "F1" "+rune"
+
+bind "F2" "dota_select_courier"
+bind "F3" "dota_courier_deliver"
+bind "F4" "dota_purchase_quickbuy"
+bind "F5" "gameui_activate"
+bind "F6" "dota_toggle_combatlog"
+
+//  Bind F7 as the quick/normal cast toggle switch
+bind "F7" "quick_normal_cast_toggle"
+
+bind "F8" "exec autoexec.cfg;con_filter_enable 0;"
+bind "F9" "dota_pause"
+
+//  Bind a key to enable/disable the net graph
 bind "F10" "custom_toggle_netgraph"
 
-// Bind F11 to enable/disable developer debug output
+//  Bind F11 to enable/disable developer debug output
 bind F11 "custom_toggle_developer"
 
+bind "F12" "jpeg"
 
 
 ////////////////////////////////////////////////////////////
-//Custom Hero Mode binds
+//  Custom Hero Mode binds                                //
 ////////////////////////////////////////////////////////////
 
-//Load the hero binds for the hero toggled currently
+//  Load the hero binds for the hero toggled currently
 load_current_hero_nomod_binds
-
-// Enable/Disable right click deny when space isn't pressed, or when u is pressed
-rc_deny_space
-bind "u" "rc_deny_mode"
-
-// Force right click deny on when o is pressed
-bind "o" "rc_deny_on"

--- a/Dota 2 Legacy Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_normal_mode_toggled.cfg
+++ b/Dota 2 Legacy Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_normal_mode_toggled.cfg
@@ -1,16 +1,16 @@
-//THIS FILE SHOULDN'T BE MODIFIED
-//It's used for switching Normal casts with Quick casts (for items/abilities) at the press of a button
+//  THIS FILE SHOULDN'T BE MODIFIED
+//  It's used for switching Normal casts with Quick casts (for items/abilities) at the press of a button
 
 
-//Normal cast alias for items
-alias toggle_enabled_use_item_0 "dota_item_execute 0"	
+//  Normal cast alias for items
+alias toggle_enabled_use_item_0 "dota_item_execute 0"
 alias toggle_enabled_use_item_1 "dota_item_execute 1"
 alias toggle_enabled_use_item_2 "dota_item_execute 2"
 alias toggle_enabled_use_item_3 "dota_item_execute 3"
 alias toggle_enabled_use_item_4 "dota_item_execute 4"
 alias toggle_enabled_use_item_5 "dota_item_execute 5"
 
-//Normal cast alias for abilities
+//  Normal cast alias for abilities
 alias toggle_enabled_use_ability_0 "dota_ability_execute 0"
 alias toggle_enabled_use_ability_1 "dota_ability_execute 1"
 alias toggle_enabled_use_ability_2 "dota_ability_execute 2"
@@ -18,9 +18,8 @@ alias toggle_enabled_use_ability_3 "dota_ability_execute 3"
 alias toggle_enabled_use_ability_4 "dota_ability_execute 4"
 alias toggle_enabled_use_ability_5 "dota_ability_execute 5"
 
-//Normal cast for Attack move
+//  Normal cast for Attack move
 alias toggle_enabled_attack "mc_attack"
 
-//Normal cast for follow/move
+//  Normal cast for follow/move
 alias toggle_enabled_follow "mc_move;
-

--- a/Dota 2 Legacy Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_normal_mode_toggled.cfg
+++ b/Dota 2 Legacy Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_normal_mode_toggled.cfg
@@ -1,22 +1,23 @@
 //  THIS FILE SHOULDN'T BE MODIFIED
-//  It's used for switching Normal casts with Quick casts (for items/abilities) at the press of a button
+//  It's used for setting all casts to normal casts (for items/abilities) at the press of a button
 
+say_team "All Items and Abilities set to Normal-Cast"
 
 //  Normal cast alias for items
-alias toggle_enabled_use_item_0 "dota_item_execute 0"
-alias toggle_enabled_use_item_1 "dota_item_execute 1"
-alias toggle_enabled_use_item_2 "dota_item_execute 2"
-alias toggle_enabled_use_item_3 "dota_item_execute 3"
-alias toggle_enabled_use_item_4 "dota_item_execute 4"
-alias toggle_enabled_use_item_5 "dota_item_execute 5"
+toggle_normal_cast_item_0
+toggle_normal_cast_item_1
+toggle_normal_cast_item_2
+toggle_normal_cast_item_3
+toggle_normal_cast_item_4
+toggle_normal_cast_item_5
 
 //  Normal cast alias for abilities
-alias toggle_enabled_use_ability_0 "dota_ability_execute 0"
-alias toggle_enabled_use_ability_1 "dota_ability_execute 1"
-alias toggle_enabled_use_ability_2 "dota_ability_execute 2"
-alias toggle_enabled_use_ability_3 "dota_ability_execute 3"
-alias toggle_enabled_use_ability_4 "dota_ability_execute 4"
-alias toggle_enabled_use_ability_5 "dota_ability_execute 5"
+toggle_normal_cast_ability_0
+toggle_normal_cast_ability_1
+toggle_normal_cast_ability_2
+toggle_normal_cast_ability_3
+toggle_normal_cast_ability_4
+toggle_normal_cast_ability_5
 
 //  Normal cast for Attack move
 alias toggle_enabled_attack "mc_attack"

--- a/Dota 2 Legacy Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_quick_mode_toggled.cfg
+++ b/Dota 2 Legacy Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_quick_mode_toggled.cfg
@@ -1,21 +1,23 @@
 //  THIS FILE SHOULDN'T BE MODIFIED
-//  It's used for switching Normal casts with Quick casts (for items/abilities) at the press of a button
+//  It's used for setting all casts to quick casts (for items/abilities) at the press of a button
+
+say_team "All items and abilities set to Quick-Cast"
 
 //  Quick cast alias for items
-alias toggle_enabled_use_item_0 "dota_item_quick_cast 0"
-alias toggle_enabled_use_item_1 "dota_item_quick_cast 1"
-alias toggle_enabled_use_item_2 "dota_item_quick_cast 2"
-alias toggle_enabled_use_item_3 "dota_item_quick_cast 3"
-alias toggle_enabled_use_item_4 "dota_item_quick_cast 4"
-alias toggle_enabled_use_item_5 "dota_item_quick_cast 5"
+toggle_quick_cast_item_0
+toggle_quick_cast_item_1
+toggle_quick_cast_item_2
+toggle_quick_cast_item_3
+toggle_quick_cast_item_4
+toggle_quick_cast_item_5
 
 //  Quick cast alias for abilities
-alias toggle_enabled_use_ability_0 "dota_ability_quickcast 0"
-alias toggle_enabled_use_ability_1 "dota_ability_quickcast 1"
-alias toggle_enabled_use_ability_2 "dota_ability_quickcast 2"
-alias toggle_enabled_use_ability_3 "dota_ability_quickcast 3"
-alias toggle_enabled_use_ability_4 "dota_ability_quickcast 4"
-alias toggle_enabled_use_ability_5 "dota_ability_quickcast 5"
+toggle_quick_cast_ability_0
+toggle_quick_cast_ability_1
+toggle_quick_cast_ability_2
+toggle_quick_cast_ability_3
+toggle_quick_cast_ability_4
+toggle_quick_cast_ability_5
 
 //  Quick cast for Attack move
 alias toggle_enabled_attack "mc_attack; +sixense_left_click; -sixense_left_click"

--- a/Dota 2 Legacy Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_quick_mode_toggled.cfg
+++ b/Dota 2 Legacy Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_quick_mode_toggled.cfg
@@ -1,15 +1,15 @@
-//THIS FILE SHOULDN'T BE MODIFIED
-//It's used for switching Normal casts with Quick casts (for items/abilities) at the press of a button
+//  THIS FILE SHOULDN'T BE MODIFIED
+//  It's used for switching Normal casts with Quick casts (for items/abilities) at the press of a button
 
-//Quick cast alias for items
-alias toggle_enabled_use_item_0 "dota_item_quick_cast 0"	
+//  Quick cast alias for items
+alias toggle_enabled_use_item_0 "dota_item_quick_cast 0"
 alias toggle_enabled_use_item_1 "dota_item_quick_cast 1"
 alias toggle_enabled_use_item_2 "dota_item_quick_cast 2"
 alias toggle_enabled_use_item_3 "dota_item_quick_cast 3"
 alias toggle_enabled_use_item_4 "dota_item_quick_cast 4"
 alias toggle_enabled_use_item_5 "dota_item_quick_cast 5"
 
-//Quick cast alias for abilities
+//  Quick cast alias for abilities
 alias toggle_enabled_use_ability_0 "dota_ability_quickcast 0"
 alias toggle_enabled_use_ability_1 "dota_ability_quickcast 1"
 alias toggle_enabled_use_ability_2 "dota_ability_quickcast 2"
@@ -17,9 +17,8 @@ alias toggle_enabled_use_ability_3 "dota_ability_quickcast 3"
 alias toggle_enabled_use_ability_4 "dota_ability_quickcast 4"
 alias toggle_enabled_use_ability_5 "dota_ability_quickcast 5"
 
-//Quick cast for Attack move
+//  Quick cast for Attack move
 alias toggle_enabled_attack "mc_attack; +sixense_left_click; -sixense_left_click"
 
-//Quick cast for follow/move
+//  Quick cast for follow/move
 alias toggle_enabled_follow "mc_move;+sixense_left_click; -sixense_left_click"
-

--- a/Dota 2 Legacy Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_space_pressed.cfg
+++ b/Dota 2 Legacy Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_space_pressed.cfg
@@ -12,8 +12,8 @@ unbindall
 //  Keep SPACE as the modifier
 bind "SPACE" "+keyShift"
 
-//  Load the secondary cast mode keys for abilities and items
-load_secondary_cast_mode
+//  Set ALT+SPACE to be a modifier
+bind "ALT" "+keyShift3"
 
 
 ////////////////////////////////////////////////////////////
@@ -21,20 +21,20 @@ load_secondary_cast_mode
 ////////////////////////////////////////////////////////////
 
 //  Mode toggled (Quick or Normal cast) cast for items
-bind "mouse5" "toggle_enabled_use_item_0"
-bind "D" "toggle_enabled_use_item_1"
-bind "F" "toggle_enabled_use_item_2"
-bind "X" "toggle_enabled_use_item_3"
-bind "C" "toggle_enabled_use_item_4"
-bind "V" "toggle_enabled_use_item_5"
+bind "mouse5" "alt_use_item_0"
+bind "D" "alt_use_item_1"
+bind "F" "alt_use_item_2"
+bind "X" "alt_use_item_3"
+bind "C" "alt_use_item_4"
+bind "V" "alt_use_item_5"
 
 //  Mode toggled (Quick or Normal cast) cast for abilities
-bind "Q" "toggle_enabled_use_ability_0"
-bind "W" "toggle_enabled_use_ability_1"
-bind "E" "toggle_enabled_use_ability_2"
-bind "T" "toggle_enabled_use_ability_3"
-bind "G" "toggle_enabled_use_ability_4"
-bind "R" "toggle_enabled_use_ability_5"
+bind "Q" "alt_use_ability_0"
+bind "W" "alt_use_ability_1"
+bind "E" "alt_use_ability_2"
+bind "T" "alt_use_ability_3"
+bind "G" "alt_use_ability_4"
+bind "R" "alt_use_ability_5"
 
 //  Hold
 bind "S" "dota_hold"

--- a/Dota 2 Legacy Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_space_pressed.cfg
+++ b/Dota 2 Legacy Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_space_pressed.cfg
@@ -1,66 +1,26 @@
 ////////////////////////////////////////////////////////////////////////////
-//Spacebar is pressed, shifting keyboard functions
+//  Spacebar is pressed, shifting keyboard functions                      //
 ////////////////////////////////////////////////////////////////////////////
 
-//Remove all leftover keybinds
+////////////////////////////////////////////////////////////
+//  Core Modifier Functionality                           //
+////////////////////////////////////////////////////////////
+
+//  Remove all leftover keybinds
 unbindall
 
-//Jump to next unit and center camera
-bind "TAB" "dota_cycle_selected;dota_camera_center"
-
-//Show Scoreboard
-bind "H" "+showscores"
-
-//Hold
-bind "S" "dota_hold"
-
-//Purchase sticky
-bind "B" "dota_purchase_stickybuy"
-
-//Enable chatwheel
-bind "CAPSLOCK" "+chatwheel"
-
-//Glyph key
-bind "F1" "dota_glyph"
-
-//Grab items from stash
-bind "F2" "stash_grab_all"
-
-//Courier speed burst
-bind "F3" "dota_courier_burst"
-
-
-////////////////////////////////////////////////////////////
-//Custom Shit
-////////////////////////////////////////////////////////////
-
-//Keep SPACE as the modifier
+//  Keep SPACE as the modifier
 bind "SPACE" "+keyShift"
 
-//SPACE+1 to jump camera to hero with single key
-bind "1" +tohero
-
-//SPACE+Key to jump camera to control group with single key
-bind "2" "+togroup1"
-bind "3" "+togroup2"
-bind "4" "+togroup3"
-bind "5" "+togroup4"
-bind "6" "+togroup5"
-bind "7" "+togroup6"
-bind "8" "+togroup7"
-bind "9" "+togroup8"
-bind "0" "+togroup9"
-
-//SPACE+A to move/follow
-bind "A" "toggle_enabled_follow"
-
-//Load the secondary cast mode keys for abilities and items
+//  Load the secondary cast mode keys for abilities and items
 load_secondary_cast_mode
 
-//UPGRADE COURIER (Good for those moments when the courier is one flying hit away from dying and you don't have time to browse the shop)
-bind "F4" "quick_upgrade_courier"
 
-//Mode toggled (Quick or Normal cast) cast for items
+////////////////////////////////////////////////////////////
+//  Binds                                                 //
+////////////////////////////////////////////////////////////
+
+//  Mode toggled (Quick or Normal cast) cast for items
 bind "mouse5" "toggle_enabled_use_item_0"
 bind "D" "toggle_enabled_use_item_1"
 bind "F" "toggle_enabled_use_item_2"
@@ -68,7 +28,7 @@ bind "X" "toggle_enabled_use_item_3"
 bind "C" "toggle_enabled_use_item_4"
 bind "V" "toggle_enabled_use_item_5"
 
-//Mode toggled (Quick or Normal cast) cast for abilities
+//  Mode toggled (Quick or Normal cast) cast for abilities
 bind "Q" "toggle_enabled_use_ability_0"
 bind "W" "toggle_enabled_use_ability_1"
 bind "E" "toggle_enabled_use_ability_2"
@@ -76,11 +36,35 @@ bind "T" "toggle_enabled_use_ability_3"
 bind "G" "toggle_enabled_use_ability_4"
 bind "R" "toggle_enabled_use_ability_5"
 
-//Toggle orb autocast
-//(one click button to toggle on every auto-cast ability, this works because no hero has more than 1 ability so it just tries to do it for all of them)
+//  Hold
+bind "S" "dota_hold"
+
+//  SPACE+A to move/follow
+bind "A" "toggle_enabled_follow"
+
+//  Toggle orb autocast
+//  (one click button to toggle on every auto-cast ability, this works because no hero has more than 1 ability so it just tries to do it for all of them)
 bind "Z" "orb_toggle"
 
-//Binds to enable you to communicate with your team with your right side of the keyboard
+//  Show Scoreboard
+bind "H" "+showscores"
+
+//  Purchase sticky
+bind "B" "dota_purchase_stickybuy"
+
+//  Glyph key
+bind "F1" "dota_glyph"
+
+//  Grab items from stash
+bind "F2" "stash_grab_all"
+
+//  Courier speed burst
+bind "F3" "dota_courier_burst"
+
+//  Enable chatwheel
+bind "CAPSLOCK" "+chatwheel"
+
+//  Binds to enable you to communicate with your team with your right side of the keyboard
 bind "U" "say_team [stack camps soon]"
 bind "I" "say_team [keep farming]"
 bind "O" "say_team [wait for everyone]"
@@ -92,13 +76,37 @@ bind "M" "say_team [all come mid]"
 bind "," "say_team [all come bot]"
 
 
+////////////////////////////////////////////////////////////
+//  Scripts                                               //
+////////////////////////////////////////////////////////////
+
+//  Jump to next unit and center camera
+bind "TAB" "dota_cycle_selected;dota_camera_center"
+
+//  SPACE+1 to jump camera to hero with single key
+bind "1" +tohero
+
+//  SPACE+Key to jump camera to control group with single key
+bind "2" "+togroup1"
+bind "3" "+togroup2"
+bind "4" "+togroup3"
+bind "5" "+togroup4"
+bind "6" "+togroup5"
+bind "7" "+togroup6"
+bind "8" "+togroup7"
+bind "9" "+togroup8"
+bind "0" "+togroup9"
+
+//  UPGRADE COURIER (Good for those moments when the courier is one flying hit away from dying and you don't have time to browse the shop)
+bind "F4" "quick_upgrade_courier"
+
 
 ////////////////////////////////////////////////////////////
-//Custom Hero Mode binds
+//  Custom Hero Mode binds                                //
 ////////////////////////////////////////////////////////////
 
-//Load the hero binds for the hero toggled currently
+//  Load the hero binds for the hero toggled currently
 load_current_hero_space_binds
 
-// Enable right click deny when space is pressed, and toggle mode is enabled
+//  Enable right click deny when space is pressed, and toggle mode is enabled
 rc_deny_space

--- a/Dota 2 Legacy Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_togglekeys.cfg
+++ b/Dota 2 Legacy Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_togglekeys.cfg
@@ -1,0 +1,109 @@
+//  THIS FILE SHOULDN'T BE MODIFIED
+//  This allows for abilities and items to be individually toggled between normal and quick cast types.
+
+//  Creates Aliases for quick-casts and normal casts for neater scripts, and more predictable behavior
+alias "quick_ability_0" "dota_ability_quickcast 0"
+alias "quick_ability_1" "dota_ability_quickcast 1"
+alias "quick_ability_2" "dota_ability_quickcast 2"
+alias "quick_ability_3" "dota_ability_quickcast 3"
+alias "quick_ability_4" "dota_ability_quickcast 4"
+alias "quick_ability_5" "dota_ability_quickcast 5"
+
+alias "normal_ability_0" "dota_ability_execute 0"
+alias "normal_ability_1" "dota_ability_execute 1"
+alias "normal_ability_2" "dota_ability_execute 2"
+alias "normal_ability_3" "dota_ability_execute 3"
+alias "normal_ability_4" "dota_ability_execute 4"
+alias "normal_ability_5" "dota_ability_execute 5"
+
+alias "quick_item_0" "dota_item_quick_cast 0"
+alias "quick_item_1" "dota_item_quick_cast 1"
+alias "quick_item_2" "dota_item_quick_cast 2"
+alias "quick_item_3" "dota_item_quick_cast 3"
+alias "quick_item_4" "dota_item_quick_cast 4"
+alias "quick_item_5" "dota_item_quick_cast 5"
+
+alias "normal_item_0" "dota_item_execute 0"
+alias "normal_item_1" "dota_item_execute 1"
+alias "normal_item_2" "dota_item_execute 2"
+alias "normal_item_3" "dota_item_execute 3"
+alias "normal_item_4" "dota_item_execute 4"
+alias "normal_item_5" "dota_item_execute 5"
+
+
+//  Set default state of Ability toggles
+alias "enabled_use_ability_0" "quick_ability_0"
+alias "enabled_use_ability_1" "quick_ability_1"
+alias "enabled_use_ability_2" "quick_ability_2"
+alias "enabled_use_ability_3" "quick_ability_3"
+alias "enabled_use_ability_4" "quick_ability_4"
+alias "enabled_use_ability_5" "quick_ability_5"
+
+//  Set default state of Item toggles
+alias "enabled_use_item_0" "quick_item_0"
+alias "enabled_use_item_1" "quick_item_1"
+alias "enabled_use_item_2" "quick_item_2"
+alias "enabled_use_item_3" "quick_item_3"
+alias "enabled_use_item_4" "quick_item_4"
+alias "enabled_use_item_5" "quick_item_5"
+
+//  Set default state of Space+Ability toggles
+alias "alt_use_ability_0" "normal_ability_0"
+alias "alt_use_ability_1" "normal_ability_1"
+alias "alt_use_ability_2" "normal_ability_2"
+alias "alt_use_ability_3" "normal_ability_3"
+alias "alt_use_ability_4" "normal_ability_4"
+alias "alt_use_ability_5" "normal_ability_5"
+
+//  Set default state of Space+Item toggles
+alias "alt_use_item_0" "normal_item_0"
+alias "alt_use_item_1" "normal_item_1"
+alias "alt_use_item_2" "normal_item_2"
+alias "alt_use_item_3" "normal_item_3"
+alias "alt_use_item_4" "normal_item_4"
+alias "alt_use_item_5" "normal_item_5"
+
+//  Toggle Quick/Normal Cast Abilities
+alias "toggle_cast_type_ability_0" "toggle_normal_cast_ability_0"
+alias "toggle_cast_type_ability_1" "toggle_normal_cast_ability_1"
+alias "toggle_cast_type_ability_2" "toggle_normal_cast_ability_2"
+alias "toggle_cast_type_ability_3" "toggle_normal_cast_ability_3"
+alias "toggle_cast_type_ability_4" "toggle_normal_cast_ability_4"
+alias "toggle_cast_type_ability_5" "toggle_normal_cast_ability_5"
+
+alias "toggle_normal_cast_ability_0" "alias enabled_use_ability_0 normal_ability_0;alias alt_use_ability_0 quick_ability_0;alias toggle_cast_type_ability_0 toggle_quick_cast_ability_0;say_student Ability 1: Normal Cast"
+alias "toggle_normal_cast_ability_1" "alias enabled_use_ability_1 normal_ability_1;alias alt_use_ability_1 quick_ability_1;alias toggle_cast_type_ability_1 toggle_quick_cast_ability_1;say_student Ability 2: Normal Cast"
+alias "toggle_normal_cast_ability_2" "alias enabled_use_ability_2 normal_ability_2;alias alt_use_ability_2 quick_ability_2;alias toggle_cast_type_ability_2 toggle_quick_cast_ability_2;say_student Ability 3: Normal Cast"
+alias "toggle_normal_cast_ability_3" "alias enabled_use_ability_3 normal_ability_3;alias alt_use_ability_3 quick_ability_3;alias toggle_cast_type_ability_3 toggle_quick_cast_ability_3;say_student Sub Ability 1: Normal Cast"
+alias "toggle_normal_cast_ability_4" "alias enabled_use_ability_4 normal_ability_4;alias alt_use_ability_4 quick_ability_4;alias toggle_cast_type_ability_4 toggle_quick_cast_ability_4;say_student Sub Ability 2: Normal Cast"
+alias "toggle_normal_cast_ability_5" "alias enabled_use_ability_5 normal_ability_5;alias alt_use_ability_5 quick_ability_5;alias toggle_cast_type_ability_5 toggle_quick_cast_ability_5;say_student Ability Ultimate: Normal Cast"
+
+alias "toggle_quick_cast_ability_0" "alias enabled_use_ability_0 quick_ability_0;alias alt_use_ability_0 normal_ability_0;alias toggle_cast_type_ability_0 toggle_normal_cast_ability_0;say_student Ability 1: Quick Cast"
+alias "toggle_quick_cast_ability_1" "alias enabled_use_ability_1 quick_ability_1;alias alt_use_ability_1 normal_ability_1;alias toggle_cast_type_ability_1 toggle_normal_cast_ability_1;say_student Ability 2: Quick Cast"
+alias "toggle_quick_cast_ability_2" "alias enabled_use_ability_2 quick_ability_2;alias alt_use_ability_2 normal_ability_2;alias toggle_cast_type_ability_2 toggle_normal_cast_ability_2;say_student Ability 3: Quick Cast"
+alias "toggle_quick_cast_ability_3" "alias enabled_use_ability_3 quick_ability_3;alias alt_use_ability_3 normal_ability_3;alias toggle_cast_type_ability_3 toggle_normal_cast_ability_3;say_student Sub Ability 1: Quick Cast"
+alias "toggle_quick_cast_ability_4" "alias enabled_use_ability_4 quick_ability_4;alias alt_use_ability_4 normal_ability_4;alias toggle_cast_type_ability_4 toggle_normal_cast_ability_4;say_student Sub Ability 2: Quick Cast"
+alias "toggle_quick_cast_ability_5" "alias enabled_use_ability_5 quick_ability_5;alias alt_use_ability_5 normal_ability_5;alias toggle_cast_type_ability_5 toggle_normal_cast_ability_5;say_student Ability Ultimate: Quick Cast"
+
+
+//  Toggle Quick/Normal Cast Items
+alias "toggle_cast_type_item_0" "toggle_normal_cast_item_0"
+alias "toggle_cast_type_item_1" "toggle_normal_cast_item_1"
+alias "toggle_cast_type_item_2" "toggle_normal_cast_item_2"
+alias "toggle_cast_type_item_3" "toggle_normal_cast_item_3"
+alias "toggle_cast_type_item_4" "toggle_normal_cast_item_4"
+alias "toggle_cast_type_item_5" "toggle_normal_cast_item_5"
+
+alias "toggle_normal_cast_item_0" "alias enabled_use_item_0 normal_item_0;alias alt_use_item_0 quick_item_0;alias toggle_cast_type_item_0 toggle_quick_cast_item_0;say_student Item 1: Normal Cast"
+alias "toggle_normal_cast_item_1" "alias enabled_use_item_1 normal_item_1;alias alt_use_item_1 quick_item_1;alias toggle_cast_type_item_1 toggle_quick_cast_item_1;say_student Item 2: Normal Cast"
+alias "toggle_normal_cast_item_2" "alias enabled_use_item_2 normal_item_2;alias alt_use_item_2 quick_item_2;alias toggle_cast_type_item_2 toggle_quick_cast_item_2;say_student Item 3: Normal Cast"
+alias "toggle_normal_cast_item_3" "alias enabled_use_item_3 normal_item_3;alias alt_use_item_3 quick_item_3;alias toggle_cast_type_item_3 toggle_quick_cast_item_3;say_student Item 4: Normal Cast"
+alias "toggle_normal_cast_item_4" "alias enabled_use_item_4 normal_item_4;alias alt_use_item_4 quick_item_4;alias toggle_cast_type_item_4 toggle_quick_cast_item_4;say_student Item 5: Normal Cast"
+alias "toggle_normal_cast_item_5" "alias enabled_use_item_5 normal_item_5;alias alt_use_item_5 quick_item_5;alias toggle_cast_type_item_5 toggle_quick_cast_item_5;say_student Item 6: Normal Cast"
+
+alias "toggle_quick_cast_item_0" "alias enabled_use_item_0 quick_item_0;alias alt_use_item_0 normal_item_0;alias toggle_cast_type_item_0 toggle_normal_cast_item_0;say_student Item 1: Quick Cast"
+alias "toggle_quick_cast_item_1" "alias enabled_use_item_1 quick_item_1;alias alt_use_item_1 normal_item_1;alias toggle_cast_type_item_1 toggle_normal_cast_item_1;say_student Item 2: Quick Cast"
+alias "toggle_quick_cast_item_2" "alias enabled_use_item_2 quick_item_2;alias alt_use_item 2 normal_item_2;alias toggle_cast_type_item_2 toggle_normal_cast_item_2;say_student Item 3: Quick Cast"
+alias "toggle_quick_cast_item_3" "alias enabled_use_item_3 quick_item_3;alias alt_use_item_3 normal_item_3;alias toggle_cast_type_item_3 toggle_normal_cast_item_3;say_student Item 4: Quick Cast"
+alias "toggle_quick_cast_item_4" "alias enabled_use_item_4 quick_item_4;alias alt_use_item_4 normal_item_4;alias toggle_cast_type_item_4 toggle_normal_cast_item_4;say_student Item 5: Quick Cast"
+alias "toggle_quick_cast_item_5" "alias enabled_use_item_5 quick_item_5;alias alt_use_item_5 normal_item_5;alias toggle_cast_type_item_5 toggle_normal_cast_item_5;say_student Item 6: Quick Cast"

--- a/Dota 2 Legacy Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_settings_game.cfg
+++ b/Dota 2 Legacy Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_settings_game.cfg
@@ -1,211 +1,205 @@
+////////////////////////////////////////////////////////////
+//  General Game Settings                                 //
+////////////////////////////////////////////////////////////
 
-////////////////////////////////////////////////////////////
-//General Game Settings
-////////////////////////////////////////////////////////////
- 
-//Option to make the attack key be quick cast
+//  Option to make the attack key be quick cast
 dota_settings_quick_target_attack 1
- 
-//Option to auto repeat right mouse
-dota_player_auto_repeat_right_mouse 1 
 
-//Allow alt+right click to force movement in a direction.
+//  Option to auto repeat right mouse
+dota_player_auto_repeat_right_mouse 1
+
+//  Allow alt+right click to force movement in a direction.
 dota_unit_allow_moveto_direction 1
- 
-//Option to right click to deny creeps instead of A + Clicking
+
+//  Option to right click to deny creeps instead of A + Clicking
 dota_force_right_click_attack "1"
 
-//Flying units, like Firefly Batrider get raised by this height above ground
-dota_unit_fly_bonus_height "10" 
- 
-//Auto purchase items (off).
-dota_player_auto_purchase_items "0"     
+//  Flying units, like Firefly Batrider get raised by this height above ground
+dota_unit_fly_bonus_height "10"
 
-//Double tap ability self cast
-dota_ability_quick_cast "1"            
- 
-//Unified unit orders (on).
-dota_player_multipler_orders "1"        
+//  Auto purchase items (off).
+dota_player_auto_purchase_items "0"
 
-//Really bad option if enabled, can fuck up your TPs
-dota_reset_camera_on_spawn "0"
+//  Double tap ability self cast
+dota_ability_quick_cast "1"
 
-//Disables hero autoattack by default
-dota_player_units_auto_attack "0"
-dota_player_units_auto_attack_after_spell "0"  
- 
-//Auto add spawned summons to control group
-dota_player_add_summoned_to_selection "1" 
-
-//Shows spells are within casting range of targeted area/target with the help of an arrow
-dota_disable_range_finder 0         
-
-//Alt modifier + qwe/asd to be inv keys (off).
-dota_gamescom_althack "0"               
-
-//Lock mouse in the window mode (Window mode).
-dota_mouse_window_lock "1"              
-
-
-
-////////////////////////////////////////////////////////////
-//Interface related
-////////////////////////////////////////////////////////////
-
-//Prevents you from double pressing to self cast (or makes it really fast so that it only happens with scripts)
+//  Prevents you from double pressing to self cast (or makes it really fast so that it only happens with scripts)
 dota_ability_self_cast_timeout 0.01
 
-//Change the item (tp scroll by default) placed in the sticky section of the quickbuy panel.
+//  Unified unit orders (on).
+dota_player_multipler_orders "1"
+
+//  Really bad option if enabled, can fuck up your TPs
+dota_reset_camera_on_spawn "0"
+
+//  Disables hero autoattack by default
+dota_player_units_auto_attack "0"
+dota_player_units_auto_attack_after_spell "0"
+
+//  Auto add spawned summons to control group
+dota_player_add_summoned_to_selection "1"
+
+//  Shows spells are within casting range of targeted area/target with the help of an arrow
+dota_disable_range_finder 0
+
+//  Alt modifier + qwe/asd to be inventory keys (off).
+dota_gamescom_althack "0"
+
+//  Lock mouse in the window mode (Window mode).
+dota_mouse_window_lock "1"
+
+
+////////////////////////////////////////////////////////////
+//  Interface related                                     //
+////////////////////////////////////////////////////////////
+
+//  Change the item (tp scroll by default) placed in the sticky section of the quickbuy panel.
 hud_sticky_item_name "item_tpscroll"
 
-// show crit, gold, xp overhead
-dota_hud_show_overhead_events "1" 
+//  show crit, gold, xp overhead
+dota_hud_show_overhead_events "1"
 
-//Shows player names above heroes
+//  Shows player names above heroes
 dota_always_show_player_names "1"
 
-//Health is split up into sections (default=250)
+//  Health is split up into sections (default=250)
 dota_health_per_vertical_marker "200"
 
-//HP bars (Disables "0";No dividing blocks "1";Normal "3").
-dota_hud_healthbars "3"                 
+//  HP bars (Disables "0";No dividing blocks "1";Normal "3").
+dota_hud_healthbars "3"
 
-//Opacity major healthbar divider.
-dota_health_marker_major_alpha "255"    
+//  Opacity major healthbar divider.
+dota_health_marker_major_alpha "255"
 
-//Opacity minor healthbar divider.
-dota_health_marker_minor_alpha "128"    
+//  Opacity minor healthbar divider.
+dota_health_marker_minor_alpha "128"
 
-//Glowing of creeps HP bar.
-dota_hud_healthbar_hoveroutline_alpha "255"  
+//  Glowing of creeps HP bar.
+dota_hud_healthbar_hoveroutline_alpha "255"
 
-//Shop uses hotkeys when opened
+//  Shop uses hotkeys when opened
 dota_shop_force_hotkeys "1"
 
-//Fade time on DMG done/received
-//(I keep all of them to 0 to be instant and have the best feedback when I get )
-dota_health_hurt_decay_time_max "0"  
+//  Fade time on damage done/received
+//  (I keep all of them to 0 to be instant and have the best feedback when I get )
+dota_health_hurt_decay_time_max "0"
 dota_health_hurt_decay_time_min "0"
 dota_health_hurt_delay "0"
 dota_pain_decay "0"
 dota_pain_factor "0"
 dota_pain_multiplier "0"
-dota_pain_fade_rate "0"   
+dota_pain_fade_rate "0"
 
-//Reverse camera grip 
+//  Reverse camera grip
 dota_camera_reverse "0"
 
-//Displays error msgs on hud (e.g. spell is on cool down)
-dota_sf_hud_error_msg "1"               
+//  Displays error messsages on HUD (e.g. spell is on cool down)
+dota_sf_hud_error_msg "1"
 
-//Display time of Firstblood, killstreaks and multikills notifications.
-dota_sf_hud_header_display_time "3"     
+//  Display time of First-blood, kill-streaks and multi-kills notifications.
+dota_sf_hud_header_display_time "3"
 
-//Shop view mode (default).
-dota_shop_view_mode "0"                 
+//  Shop view mode (default).
+dota_shop_view_mode "0"
 
-//Shop tree animation (off).
-dota_sf_hud_shop_tree_animtime "0"      
-
+//  Shop tree animation (off).
+dota_sf_hud_shop_tree_animtime "0"
 
 
 ////////////////////////////////////////////////////////////
-//Minimap related
+//  Minimap related                                       //
 ////////////////////////////////////////////////////////////
 
-//Changes the size of heroes on the minimap
-//(I like a high value so I can see their portrait flash on the minimap)
-dota_minimap_hero_size 1100  
+//  Changes the size of heroes on the minimap
+//  (I like a high value so I can see their portrait flash on the minimap)
+dota_minimap_hero_size 1100
 
-//Minimum time after the mouse enters the minimap before we accept a move command
+//  Minimum time after the mouse enters the minimap before we accept a move command
 dota_minimap_misclick_time "0"
 
-//Minimap icons instead of names
-dota_minimap_show_hero_icon "1" 
+//  Minimap icons instead of names
+dota_minimap_show_hero_icon "1"
 
-//Always draws the hero icons instead of the colored arrows/crosses (like having default ALT always pressed)
+//  Always draws the hero icons instead of the colored arrows/crosses (like having default ALT always pressed)
 dota_minimap_always_draw_hero_icons "1"
 
-//Hold alt to highligth hero
-dota_show_hero_finder "0" 
+//  Hold alt to highlight hero
+dota_show_hero_finder "0"
 
-//Minimap using simple colors
-dota_minimap_simple_colors "0"
+//  Minimap hide background
+dota_minimap_hide_background "0"
 
-//Minimap hide background 
-dota_minimap_hide_background "0"     
-
-//Distance from tower to iniate ping tower instead of ping map. 
+//  Distance from tower to initiate ping tower instead of ping map.
 dota_minimap_tower_defend_distance "150"
 
-//Duration of regular pings.
-dota_minimap_ping_duration "4"          
+//  Duration of regular pings.
+dota_minimap_ping_duration "4"
 
-//Duration of shield/attack pings on towers.
-dota_minimap_ping_tag_duration "4"      
+//  Duration of shield/attack pings on towers.
+dota_minimap_ping_tag_duration "4"
 
-//Shadow size for the hero name that is drawn on the map
-dota_minimap_hero_name_shadowsize "4"   
-                
-//Minimap colors for enemies, neutrals and friendlies (expressed in red/green/blue pairs) 
-dota_enemy_color_r "1"                                        
-dota_enemy_color_g "0"                  
-dota_enemy_color_b "0"                 
-dota_neutral_color_r "0"               
-dota_neutral_color_g "1"                
-dota_neutral_color_b "0"               
-dota_friendly_color_r "1"                 
-dota_friendly_color_g "1"               
-dota_friendly_color_b "1"               
+//  Shadow size for the hero name that is drawn on the map
+dota_minimap_hero_name_shadowsize "4"
 
+//  Minimap using simple colors
+dota_minimap_simple_colors "0"
 
- 
-////////////////////////////////////////////////////////////
-//Camera and shit
-////////////////////////////////////////////////////////////
- 
-//Camera move speed with edge pan
-//I like a high value, because I use mouse grip most of the time
-dota_camera_speed "10000"
+//  Minimap colors for enemies, neutrals and friendlies (expressed in red/green/blue pairs)
+dota_enemy_color_r "1"
+dota_enemy_color_g "0"
+dota_enemy_color_b "0"
+dota_neutral_color_r "0"
+dota_neutral_color_g "1"
+dota_neutral_color_b "0"
+dota_friendly_color_r "1"
+dota_friendly_color_g "1"
+dota_friendly_color_b "1"
 
-//Camera acceleration (50 = almost no acceleration)
-dota_camera_accelerate 50
-
-//Smoothing of camera.
-dota_camera_smooth_enable "0"           
-
-//Power of smoothing and other smoothing parameters
-dota_camera_smooth_count "0"            
-dota_camera_smooth_distance "96"        
- 
-//To disable the annoying camera zoom in with mouse wheel scroll
-dota_camera_disable_zoom "1"
-
-//Enables moving the camera by touching the edge of the screen with mouse
-dota_camera_edgemove "1" 
- 
-//Double tap to select and move the camera to your hero.
-dota_camera_follow_doublepress_time "0.5" 
-
-//Stops the screen shaking when certain spells are cast
-dota_screen_shake "0"
-
-//Enables edge shift when camera locked on hero
-dota_camera_lock_view_helper 0
-
-//Edge shift when camera locked on hero (default:220)
-dota_camera_lock_mouse_lead 700
-
-// Minimap icon scaling by heroes proximity to each other
-// When heroes are close together, their icons will be reduced in size on the minimap so that you can more easily see
-// who is there from the minimap. Without this, icons close together will overlap more and its hard to tell who is
-// there by looking at the minimap.
+//  Minimap icon scaling by heroes proximity to each other
+//  heroes are close together, their icons will be reduced in size on the minimap so that you can more easily see
+//  who is there from the minimap. Without this, icons close together will overlap more and its hard to tell who is
+//  there by looking at the minimap.
 dota_minimap_hero_scalar 1
 
-// Proximity in pixels to begin scaling (default 12)
+//  Proximity in pixels to begin scaling (default 12)
 dota_minimap_hero_scalar_distance 20
- 
-// Minimum scaled size (default 500)
+
+//  Minimum scaled size (default 500)
 dota_minimap_hero_scalar_minimum 600
 
- 
+
+////////////////////////////////////////////////////////////
+//  Camera and shit                                       //
+////////////////////////////////////////////////////////////
+
+//  Camera move speed with edge pan
+//  I like a high value, because I use mouse grip most of the time
+dota_camera_speed "10000"
+
+//  Camera acceleration (50 = almost no acceleration)
+dota_camera_accelerate 50
+
+//  Smoothing of camera.
+dota_camera_smooth_enable "0"
+
+//  Power of smoothing and other smoothing parameters
+dota_camera_smooth_count "0"
+dota_camera_smooth_distance "96"
+
+//  To disable the annoying camera zoom in with mouse wheel scroll
+dota_camera_disable_zoom "1"
+
+//  Enables moving the camera by touching the edge of the screen with mouse
+dota_camera_edgemove "1"
+
+//  Double tap to select and move the camera to your hero.
+dota_camera_follow_doublepress_time "0.5"
+
+//  Stops the screen shaking when certain spells are cast
+dota_screen_shake "0"
+
+//  Enables edge shift when camera locked on hero
+dota_camera_lock_view_helper 0
+
+//  Edge shift when camera locked on hero (default:220)
+dota_camera_lock_mouse_lead 700

--- a/Dota 2 Legacy Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_settings_tech.cfg
+++ b/Dota 2 Legacy Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_settings_tech.cfg
@@ -1,62 +1,62 @@
 ////////////////////////////////////////////////////////////
-//Graphics, Performance and shit
+//  Graphics, Performance and shit                        //
 ////////////////////////////////////////////////////////////
-fps_max "60"				//Forces client to a max FPS limit
-mat_vsync "0"				
-mat_triplebuffered "0"                  //Enable with vsync for a performance boost if fps is less than 60.
-dota_cheap_water 1                      //Crappy water, better performance
-cl_globallight_shadow_mode 0		//Shadow options
-r_deferred_height_fog 0			//Fog
-r_deferred_simple_light 1		//World Lighting
-r_deferred_additive_pass "0"            //Additive light pass  
-r_deferred_specular "0"                 //Specular 
-r_deferred_specular_bloom "0"           //Specular bloom 
-r_screenspace_aa 0			//Anti-aliasing 
-r_ssao "0"                              //Ambient occlusion 
-mat_picmip "0"                          //Textures quality (high).
-dota_embers "0" 			//turns off fire on mainmenu, less gpu/cpu load
-sv_forcepreload "1"			//Force server side preloading. 
-engine_no_focus_sleep "0"               //Reduces resources consumed when dota 2 loses focus.
-dota_portrait_animate "1"               //Hero portrait animations 
-dota_ambient_creatures "0"              //Ambient creatures 
 
-//Some poeple got a fps boost enabling this one
-//r_fastzreject 1
+fps_max "60"                            //  Forces client to a max FPS limit
+mat_vsync "0"
+mat_triplebuffered "0"                  //  Enable with vsync for a performance boost if fps is less than 60.
+dota_cheap_water 1                      //  Crappy water, better performance
+cl_globallight_shadow_mode 0            //  Shadow options
+r_deferred_height_fog 0                 //  Fog
+r_deferred_simple_light 1               //  World Lighting
+r_deferred_additive_pass "0"            //  Additive light pass
+r_deferred_specular "0"                 //  Specular
+r_deferred_specular_bloom "0"           //  Specular bloom
+r_screenspace_aa 0                      //  Anti-aliasing
+r_ssao "0"                              //  Ambient occlusion
+mat_picmip "0"                          //  Textures quality (high).
+dota_embers "0"                         //  turns off fire on mainmenu, less gpu/cpu load
+sv_forcepreload "1"                     //  Force server side preloading.
+engine_no_focus_sleep "0"               //  Reduces resources consumed when dota 2 loses focus.
+dota_portrait_animate "1"               //  Hero portrait animations
+dota_ambient_creatures "0"              //  Ambient creatures
+
+//  Some poeple got a fps boost enabling this one
+//  r_fastzreject 1
 
 
 ////////////////////////////////////////////////////////////
-//Netcode Shit
-//Altough the lerp value will probably blink red/yellowish in your netgraph, tests have shown that this is likely the most responsive setup possible.
+//  Netcode Shit
+//  Altough the lerp value will probably blink red/yellowish in your netgraph, tests have shown that this is likely the most responsive setup possible.
 ////////////////////////////////////////////////////////////
- 
-cl_interp "0.033"                       // Interpolate object positions starting this many seconds in past                      (Default 0.055, Min 0.033)
-cl_interp_ratio "1"                     // Multiplies final result of cl_interp                                                 (Default 2)
-cl_smoothtime "0.01"                    // When errors occur smooth display over X time, 0 Disables                             (Default 0.1)
-rate "80000"                            // Total amount of bandwidth Dota 2 may use                                             (Default 80000)
-cl_updaterate "30"                      // Amount of updates recieved from server per second                                    (Default 30, Max 30)
-cl_cmdrate "30"                         // Amount of updates sent to server per second                                          (Default 30, Max 30)
+
+cl_interp "0.033"                       // Interpolate object positions starting this many seconds in past     (Default 0.055, Min 0.033)
+cl_interp_ratio "1"                     // Multiplies final result of cl_interp                                (Default 2)
+cl_smoothtime "0.01"                    // When errors occur smooth display over X time, 0 Disables            (Default 0.1)
+rate "80000"                            // Total amount of bandwidth Dota 2 may use                            (Default 80000)
+cl_updaterate "30"                      // Amount of updates recieved from server per second                   (Default 30, Max 30)
+cl_cmdrate "30"                         // Amount of updates sent to server per second                         (Default 30, Max 30)
 cl_smooth "1"
 cl_lagcompensation "1"
 cl_pred_optimize "2"
- 
-//For netgraph display (netgraph properties)
+
+//  For netgraph display (netgraph properties)
 net_graphinsetbottom "436"
 net_graphinsetright "-68"
 net_graphproportionalfont "0"
 
 snd_updateaudiocache
- 
+
 
 ////////////////////////////////////////////////////////////
-//Multicore Support
-//Recommended only if you're running multi-core
+//  Multicore Support                                     //
+//  Recommended only if you're running multi-core         //
 ////////////////////////////////////////////////////////////
-//r_threaded_shadow_clip 1
-//r_queued_decals 1
-//r_queued_post_processing 1
-//mat_queue_mode 2			//Quad core rendering.
-//cl_threaded_bone_setup 1
-//cl_threaded_init 1
-//snd_mix_async "1"                     //Multicore sound rendering
 
- 
+//  r_threaded_shadow_clip 1
+//  r_queued_decals 1
+//  r_queued_post_processing 1
+//  mat_queue_mode 2               //Quad core rendering.
+//  cl_threaded_bone_setup 1
+//  cl_threaded_init 1
+//  snd_mix_async "1"              //Multicore sound rendering

--- a/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/autoexec.cfg
+++ b/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/autoexec.cfg
@@ -1,18 +1,17 @@
 // "================================================"
 // "===========[AUTOEXEC CONFIG LOADED]============="
 // "================================================"
-// "    Loopuleasa's Super Compact Layout v5.0"
-// "          Reworked for Dota 2 Reborn"
-// "             Updated 18/06/2015"
+// "    Loopuleasa's Super Compact Layout v5.0      "
+// "          Reworked for Dota 2 Reborn            "
+// "             Updated 18/06/2015                 "
 // "================================================"
 
 //Play a confirmation sound that the autoexec loaded
 playsound sounds/ui/coins_big.vsnd_c
 
 
-
 ////////////////////////////////////////////////////////////
-//Load the game settings
+// Load the game settings                                 //
 ////////////////////////////////////////////////////////////
 
 //Load the tech settings from dota2_settings_tech.cfg
@@ -22,9 +21,8 @@ exec dota2_gameplay_mode/dota2_settings_tech.cfg
 exec dota2_gameplay_mode/dota2_settings_game.cfg
 
 
-
 ////////////////////////////////////////////////////////////
-//Load the custom hero functions
+//  Load the custom hero functions                        //
 ////////////////////////////////////////////////////////////
 
 //Sets up the active functions defined from the external file
@@ -32,14 +30,11 @@ exec dota2_gameplay_mode/dota2_functions_active.cfg
 
 
 ////////////////////////////////////////////////////////////
-//Load default Keybinds
+//  Load default Keybinds                                 //
 ////////////////////////////////////////////////////////////
-
-//This line initialises the initial cast mode state to quick cast
-quick_normal_cast_toggle
 
 //Load the regular keybinds from the external "dota2_keybinds_default.cfg" file
 exec dota2_gameplay_mode/dota2_keybinds_default.cfg
 
 //This line rebinds ALT (Ping is now on Tilde) - this is needed for ALT+ keyboard layout to work and not conflict
-dota_remap_alt_key "`" 
+dota_remap_alt_key "`"

--- a/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_functions_active.cfg
+++ b/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_functions_active.cfg
@@ -1,91 +1,98 @@
-////////////////////////////////////////////////////////////
-//Active command section - these are used throughout the other files
-////////////////////////////////////////////////////////////
-
-
+////////////////////////////////////////////////////////////////////////////
+//  Active command section - these are used throughout the other files    //
+////////////////////////////////////////////////////////////////////////////
 
 ////////////////////////////////////////////////////////////
-//Core modifier functionality
+//  Core modifier functionality                           //
 ////////////////////////////////////////////////////////////
 
-//Loads the keybinds in the "dota2_keybinds_space_pressed.cfg" file when space is pressed, and reverts to normal when depressed
+//  Loads the keybinds in the "dota2_keybinds_space_pressed.cfg" file when space is pressed, and reverts to normal when released
 alias +keyShift "exec dota2_gameplay_mode/dota2_keybinds_space_pressed.cfg"
 alias -keyShift "exec dota2_gameplay_mode/dota2_keybinds_default.cfg"
 
-//Loads the keybinds in the "dota2_keybinds_alt_pressed.cfg" file when ALT is pressed, and reverts to normal when depressed
+//  Loads the keybinds in the "dota2_keybinds_alt_pressed.cfg" file when ALT is pressed, and reverts to normal when released
 alias +keyShift2 "exec dota2_gameplay_mode/dota2_keybinds_alt_pressed.cfg"
 alias -keyShift2 "exec dota2_gameplay_mode/dota2_keybinds_default.cfg"
 
+// Loads the keybinds in the "dota2_keybinds_alt_space_pressed.cfg" file when ALT+SPACE is pressed, and reverts to normal when released
 alias +keyShift3 "exec dota2_gameplay_mode/dota2_keybinds_alt_space_pressed.cfg"
 alias -keyShift3 "exec dota2_gameplay_mode/dota2_keybinds_default.cfg"
 
 
 ////////////////////////////////////////////////////////////
-//Hero custom config switches
+//  Hero custom config switches                           //
 ////////////////////////////////////////////////////////////
 
 exec "dota2_hero_custom_configs/setup_hero_mode.cfg"
 
 
-
 ////////////////////////////////////////////////////////////
-//Toggle functionalities
+//  Toggle functionalities                                //
 ////////////////////////////////////////////////////////////
 
-//Auto attack toggle (must be first configured here to work properly)
+//  Auto attack toggle (must be first configured here to work properly)
 alias "auto_attack_toggle" "auto_attack_toggle_on"
 alias "auto_attack_toggle_on" "playsound sounds/ui/tutorial_ui_ding_01.vsnd_c;dota_player_units_auto_attack 1; dota_player_units_auto_attack_after_spell 1; alias auto_attack_toggle auto_attack_toggle_off; say_student Auto attack enabled"
 alias "auto_attack_toggle_off" "playsound sounds/ui/ui_upgrade_ability_01.vsnd_c;dota_player_units_auto_attack 0; dota_player_units_auto_attack_after_spell 0; alias auto_attack_toggle auto_attack_toggle_on; say_student Auto attack disabled"
 
-//Auto select summoned units toggle
+//  Auto select summoned units toggle
 alias "auto_select_summoned_toggle" "auto_select_summoned_toggle_off"
 alias "auto_select_summoned_toggle_on" "playsound sounds/ui/tutorial_ui_ding_01.vsnd_c;dota_player_add_summoned_to_selection 1; alias auto_select_summoned_toggle auto_select_summoned_toggle_off; say_student Select summons enabled"
 alias "auto_select_summoned_toggle_off" "playsound sounds/ui/ui_upgrade_ability_01.vsnd_c;dota_player_add_summoned_to_selection 0; alias auto_select_summoned_toggle auto_select_summoned_toggle_on; say_student Select summons disabled"
 
-//Quick or Normal cast mode toggle for items and abilities
+//  Quick or Normal cast mode toggle for items and abilities
 alias "quick_normal_cast_toggle" "quick_cast_toggled_on"
 alias "quick_cast_toggled_on" "playsound sounds/ui/tutorial_ui_ding_01.vsnd_c;alias quick_normal_cast_toggle quick_cast_toggled_off; exec dota2_gameplay_mode/dota2_keybinds_toggle_quickcast.cfg"
 alias "quick_cast_toggled_off" "playsound sounds/ui/ui_upgrade_ability_01.vsnd_c;alias quick_normal_cast_toggle quick_cast_toggled_on;exec dota2_gameplay_mode/dota2_keybinds_toggle_non-quickcast.cfg"
 
-//Used for the open mic toggle
+//  Used for the open mic toggle
 alias "mic_toggle" "openmic"
 alias "openmic" "voice_vox 1; playsound sounds/ui/tutorial_ui_ding_01.vsnd_c; alias mic_toggle closemic; say_student Open mic enabled"
 alias "closemic" "voice_vox 0; playsound sounds/ui/ui_upgrade_ability_01.vsnd_c; alias mic_toggle openmic; say_student Open mic disabled"
 
-//Toggle health segmentation between these values
+//  Toggle health segmentation between these values
 alias "toggle_segments" "toggle dota_health_per_vertical_marker 200 300 400 500; playsound sounds/ui/ui_upgrade_ability_01.vsnd_c"
 
-//Toggle netgraph on and off
+//  Toggle netgraph on and off
 alias "custom_toggle_netgraph" "show_net_graph"
 alias "show_net_graph" "dota_hud_netgraph 1; alias custom_toggle_netgraph hide_net_graph"
 alias "hide_net_graph" "dota_hud_netgraph 0; alias custom_toggle_netgraph show_net_graph"
 
-//Toggle developer mode on and off
+//  Toggle developer mode on and off
 alias "custom_toggle_developer" "developer_on"
 alias "developer_on" "developer 1; alias custom_toggle_developer developer_off; say_student Developer mode on"
 alias "developer_off" "developer 0; alias custom_toggle_developer developer_on; say_student Developer mode on"
 
-//Individual Ability/Skill Quick/Normal Cast Toggle config
+//  Individual Ability/Skill Quick/Normal Cast Toggle config
 exec dota2_gameplay_mode/dota2_keybinds_togglekeys.cfg
 
+//  Change between right-click deny on, off, space toggled
+alias "rc_deny_mode" "rc_deny_toggle"
+alias "rc_deny_space" "rc_deny_on"
+alias "rc_deny_on" "dota_force_right_click_attack 1;alias rc_deny_space null;alias rc_deny_mode rc_deny_toggle;say_student RC-Deny On"
+alias "rc_deny_toggle" "dota_force_right_click_attack 0; alias rc_deny_space rc_deny_switch;alias rc_deny_mode rc_deny_off;say_student RC-Deny Space"
+alias "rc_deny_off" "dota_force_right_click_attack 0;alias rc_deny_space null;alias rc_deny_mode rc_deny_on;say_student RC-Deny Off"
+alias "rc_deny_switch" "toggle dota_force_right_click_attack"
+
+
 ////////////////////////////////////////////////////////////
-//Custom shit
+//  Scripts                                               //
 ////////////////////////////////////////////////////////////
 
-//UPGRADE COURIER (Good for those moments when the courier is one flying hit away from dying and you don't have time to browse the shop)
+//  UPGRADE COURIER (Good for those moments when the courier is one flying hit away from dying and you don't have time to browse the shop)
 alias "quick_upgrade_courier" "dota_shop_force_hotkeys 1;toggleshoppanel;shop_nav_to_tab 0;shop_select_itemrow 8;toggleshoppanel"
 
-//A faster courier deliver items (just like the normal one, but it solves a bug that the one from volvo has), with team say
-//It solves this problem: http://www.twitch.tv/2c2c/b/564756824
-//It has one problem: if someone is using courier, it stops, so it can only be used when it is in fountain
-//It also selects the hero on press, cannot change that
+//  A faster courier deliver items (just like the normal one, but it solves a bug that the one from volvo has), with team say
+//  solves this problem: http://www.twitch.tv/2c2c/b/564756824
+//  It has one problem: if someone is using courier, it stops, so it can only be used when it is in fountain
+//  It also selects the hero on press, cannot change that
 alias "swift_courier_deliver" "dota_select_courier;stash_grab_all;dota_courier_deliver;dota_courier_burst;dota_ability_quickcast 4;+dota_camera_follow;-dota_camera_follow;say_team [requesting courier]"
 
-//Jump camera to hero with single key
+//  Jump camera to hero with single key
 alias "+tohero" "+dota_camera_follow;-dota_camera_follow;+dota_camera_follow"
 alias "-tohero" "-dota_camera_follow"
 
-//Jump camera to to control group with single key
+//  Jump camera to to control group with single key
 alias "+togroup1" "+dota_control_group 1;-dota_control_group 1;+dota_control_group 1"
 alias "-togroup1" "-dota_control_group 1"
 alias "+togroup2" "+dota_control_group 2;-dota_control_group 2;+dota_control_group 2"
@@ -105,24 +112,16 @@ alias "-togroup8" "-dota_control_group 8"
 alias "+togroup9" "+dota_control_group 9;-dota_control_group 9;+dota_control_group 9"
 alias "-togroup9" "-dota_control_group 9"
 
-//Camera grip custom key
-alias "+cameraControl" "+cameragrip;+sixense_left_click";
-alias "-cameraControl" "-cameragrip;-sixense_left_click";
-
-// Shuffle camera to rune positions while pressing the keys and back to hero on release
+//  Shuffle camera to rune positions while pressing the keys and back to hero on release
 alias "+rune" "top_rune"
 alias "-rune" "dota_recent_event; dota_recent_event; +dota_camera_follow"
 alias "top_rune" "dota_camera_set_lookatpos -2273 1800; alias +rune bottom_rune"
 alias "bottom_rune" "dota_camera_set_lookatpos 3035 -2350; alias +rune top_rune"
 
-//Toggle orb autocast
-//(one click button to toggle on every auto-cast ability, this works because no hero has more than 1 ability so it just tries to do it for all of them)
+//  Toggle orb autocast
+//  (one click button to toggle on every auto-cast ability, this works because no hero has more than 1 ability so it just tries to do it for all of them)
 alias "orb_toggle" "dota_ability_autocast 0; dota_ability_autocast 1; dota_ability_autocast 2; dota_ability_autocast 3; dota_ability_autocast 4;dota_ability_autocast 5"
 
-//Change between right-click deny on, off, space toggled
-alias "rc_deny_mode" "rc_deny_toggle"
-alias "rc_deny_space" "rc_deny_on"
-alias "rc_deny_on" "dota_force_right_click_attack 1;alias rc_deny_space null;alias rc_deny_mode rc_deny_toggle;say_student RC-Deny On"
-alias "rc_deny_toggle" "dota_force_right_click_attack 0; alias rc_deny_space rc_deny_switch;alias rc_deny_mode rc_deny_off;say_student RC-Deny Space"
-alias "rc_deny_off" "dota_force_right_click_attack 0;alias rc_deny_space null;alias rc_deny_mode rc_deny_on;say_student RC-Deny Off"
-alias "rc_deny_switch" "toggle dota_force_right_click_attack"
+//  Camera grip custom key
+alias "+cameraControl" "+cameragrip;+sixense_left_click";
+alias "-cameraControl" "-cameragrip;-sixense_left_click";

--- a/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_functions_active.cfg
+++ b/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_functions_active.cfg
@@ -80,7 +80,7 @@ alias "rc_deny_switch" "toggle dota_force_right_click_attack"
 ////////////////////////////////////////////////////////////
 
 //  UPGRADE COURIER (Good for those moments when the courier is one flying hit away from dying and you don't have time to browse the shop)
-alias "quick_upgrade_courier" "dota_shop_force_hotkeys 1;toggleshoppanel;shop_nav_to_tab 0;shop_select_itemrow 8;toggleshoppanel"
+alias "quick_upgrade_courier" "dota_shop_force_hotkeys 1;toggleshoppanel;shop_nav_to_tab 0;shop_select_itemrow 9;toggleshoppanel"
 
 //  A faster courier deliver items (just like the normal one, but it solves a bug that the one from volvo has), with team say
 //  solves this problem: http://www.twitch.tv/2c2c/b/564756824

--- a/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_functions_active.cfg
+++ b/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_functions_active.cfg
@@ -16,6 +16,8 @@ alias -keyShift "exec dota2_gameplay_mode/dota2_keybinds_default.cfg"
 alias +keyShift2 "exec dota2_gameplay_mode/dota2_keybinds_alt_pressed.cfg"
 alias -keyShift2 "exec dota2_gameplay_mode/dota2_keybinds_default.cfg"
 
+alias +keyShift3 "exec dota2_gameplay_mode/dota2_keybinds_alt_space_pressed.cfg"
+alias -keyShift3 "exec dota2_gameplay_mode/dota2_keybinds_default.cfg"
 
 
 ////////////////////////////////////////////////////////////
@@ -42,8 +44,8 @@ alias "auto_select_summoned_toggle_off" "playsound sounds/ui/ui_upgrade_ability_
 
 //Quick or Normal cast mode toggle for items and abilities
 alias "quick_normal_cast_toggle" "quick_cast_toggled_on"
-alias "quick_cast_toggled_on" "playsound sounds/ui/tutorial_ui_ding_01.vsnd_c;alias quick_normal_cast_toggle quick_cast_toggled_off;alias load_primary_cast_mode exec dota2_gameplay_mode/dota2_keybinds_toggle_quickcast.cfg; alias load_secondary_cast_mode exec dota2_gameplay_mode/dota2_keybinds_toggle_non-quickcast.cfg;exec dota2_gameplay_mode/dota2_keybinds_default.cfg; say_student Quickcast mode enabled"
-alias "quick_cast_toggled_off" "playsound sounds/ui/ui_upgrade_ability_01.vsnd_c;alias quick_normal_cast_toggle quick_cast_toggled_on;alias load_primary_cast_mode exec dota2_gameplay_mode/dota2_keybinds_toggle_non-quickcast.cfg; alias load_secondary_cast_mode exec dota2_gameplay_mode/dota2_keybinds_toggle_quickcast.cfg;exec dota2_gameplay_mode/dota2_keybinds_default.cfg; say_student Quickcast mode disabled"
+alias "quick_cast_toggled_on" "playsound sounds/ui/tutorial_ui_ding_01.vsnd_c;alias quick_normal_cast_toggle quick_cast_toggled_off; exec dota2_gameplay_mode/dota2_keybinds_toggle_quickcast.cfg"
+alias "quick_cast_toggled_off" "playsound sounds/ui/ui_upgrade_ability_01.vsnd_c;alias quick_normal_cast_toggle quick_cast_toggled_on;exec dota2_gameplay_mode/dota2_keybinds_toggle_non-quickcast.cfg"
 
 //Used for the open mic toggle
 alias "mic_toggle" "openmic"
@@ -63,7 +65,8 @@ alias "custom_toggle_developer" "developer_on"
 alias "developer_on" "developer 1; alias custom_toggle_developer developer_off; say_student Developer mode on"
 alias "developer_off" "developer 0; alias custom_toggle_developer developer_on; say_student Developer mode on"
 
-
+//Individual Ability/Skill Quick/Normal Cast Toggle config
+exec dota2_gameplay_mode/dota2_keybinds_togglekeys.cfg
 
 ////////////////////////////////////////////////////////////
 //Custom shit

--- a/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_alt_pressed.cfg
+++ b/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_alt_pressed.cfg
@@ -1,11 +1,26 @@
 ////////////////////////////////////////////////////////////////////////////
-//ALT  is pressed, shifting keyboard functions
+//  ALT  is pressed, shifting keyboard functions                          //
 ////////////////////////////////////////////////////////////////////////////
 
-//Remove all leftover keybinds
+////////////////////////////////////////////////////////////
+//  Core modifier functionality                           //
+////////////////////////////////////////////////////////////
+
+//  Remove all leftover keybinds
 unbindall
 
-//ALT to self cast for items
+//  Keep ALT as the modifier
+bind "ALT" "+keyShift2"
+
+//  Set ALT+SPACE to be a modifier
+bind "SPACE" "+keyShift3"
+
+
+////////////////////////////////////////////////////////////
+//  Custom Binds                                          //
+////////////////////////////////////////////////////////////
+
+//  ALT to self cast for items
 bind "mouse5" "dota_item_execute 0;dota_item_execute 0"
 bind "D" "dota_item_execute 1;dota_item_execute 1"
 bind "F" "dota_item_execute 2;dota_item_execute 2"
@@ -13,7 +28,7 @@ bind "X" "dota_item_execute 3;dota_item_execute 3"
 bind "C" "dota_item_execute 4;dota_item_execute 4"
 bind "V" "dota_item_execute 5;dota_item_execute 5"
 
-//ALT to self cast for abilities
+//  ALT to self cast for abilities
 bind "Q" "dota_ability_execute 0;dota_ability_execute 0"
 bind "W" "dota_ability_execute 1;dota_ability_execute 1"
 bind "E" "dota_ability_execute 2;dota_ability_execute 2"
@@ -21,49 +36,43 @@ bind "T" "dota_ability_execute 3;dota_ability_execute 3"
 bind "G" "dota_ability_execute 4;dota_ability_execute 4"
 bind "R" "dota_ability_execute 5;dota_ability_execute 5"
 
-//Auto-attack toggle (Custom command)
+//  Auto-attack toggle (Custom command)
 bind "S" "auto_attack_toggle"
 
-//Attack
+//  Attack
 bind "A" "mc_attack"
 
-//Toggle health segmetnation between some values
+//  Toggle health segmetnation between some values
 bind "Z" "toggle_segments"
 
-//Select all other units
+//  Select all other units
 bind "1" "dota_select_all"
 
-//Select all units
+//  Select all units
 bind "2" "dota_select_all_others"
 
-
-////////////////////////////////////////////////////////////
-//Custom Shit
-////////////////////////////////////////////////////////////
-
-//Keep ALT as the modifier
-bind "ALT" "+keyShift2"
-
-//Set ALT+SPACE to be a modifier
-bind "SPACE" "+keyShift3"
-
-//Key to disable/enable open mic
+//  Key to disable/enable open mic
 bind CAPSLOCK mic_toggle
 
-//Jump camera to fountains
+
+////////////////////////////////////////////////////////////
+//  Scripts                                               //
+////////////////////////////////////////////////////////////
+
+//  Jump camera to fountains
 bind "F1" "dota_camera_set_lookatpos -6989 -6553"
 bind "F2" "dota_camera_set_lookatpos 6976 6353"
 
-//A faster courier deliver items (just like the normal one, but it solves a bug that the one from volvo has), with team say
-//It solves this problem: http://www.twitch.tv/2c2c/b/564756824
-//It has one problem: if someone is using courier, it stops, so it can only be used when it is in fountain
-//It also selects the hero on press, cannot change that
+//  A faster courier deliver items (just like the normal one, but it solves a bug that the one from volvo has), with team say
+//  It solves this problem: http://www.twitch.tv/2c2c/b/564756824
+//  It has one problem: if someone is using courier, it stops, so it can only be used when it is in fountain
+//  It also selects the hero on press, cannot change that
 bind "F3" "swift_courier_deliver"
 
 
 ////////////////////////////////////////////////////////////
-//Custom Hero Mode binds
+//  Custom Hero Mode binds                                //
 ////////////////////////////////////////////////////////////
 
-//Load the hero binds for the hero toggled currently
+//  Load the hero binds for the hero toggled currently
 load_current_hero_alt_binds

--- a/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_alt_pressed.cfg
+++ b/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_alt_pressed.cfg
@@ -6,11 +6,11 @@
 unbindall
 
 //ALT to self cast for items
-bind "mouse5" "dota_item_execute 0;dota_item_execute 0"					
-bind "D" "dota_item_execute 1;dota_item_execute 1" 
-bind "F" "dota_item_execute 2;dota_item_execute 2"                    
-bind "X" "dota_item_execute 3;dota_item_execute 3"                     
-bind "C" "dota_item_execute 4;dota_item_execute 4"                   
+bind "mouse5" "dota_item_execute 0;dota_item_execute 0"
+bind "D" "dota_item_execute 1;dota_item_execute 1"
+bind "F" "dota_item_execute 2;dota_item_execute 2"
+bind "X" "dota_item_execute 3;dota_item_execute 3"
+bind "C" "dota_item_execute 4;dota_item_execute 4"
 bind "V" "dota_item_execute 5;dota_item_execute 5"
 
 //ALT to self cast for abilities
@@ -31,18 +31,21 @@ bind "A" "mc_attack"
 bind "Z" "toggle_segments"
 
 //Select all other units
-bind "1" "dota_select_all" 
+bind "1" "dota_select_all"
 
 //Select all units
-bind "2" "dota_select_all_others" 
+bind "2" "dota_select_all_others"
 
 
 ////////////////////////////////////////////////////////////
 //Custom Shit
 ////////////////////////////////////////////////////////////
 
-//Keep ALT as the modifier 
+//Keep ALT as the modifier
 bind "ALT" "+keyShift2"
+
+//Set ALT+SPACE to be a modifier
+bind "SPACE" "+keyShift3"
 
 //Key to disable/enable open mic
 bind CAPSLOCK mic_toggle

--- a/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_alt_space_pressed.cfg
+++ b/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_alt_space_pressed.cfg
@@ -1,14 +1,23 @@
 ////////////////////////////////////////////////////////////////////////////
-//Alt + Space is pressed, shifting keyboard functions
+//  Alt + Space is pressed, shifting keyboard functions                   //
 ////////////////////////////////////////////////////////////////////////////
 
-//Remove all leftover keybinds
+////////////////////////////////////////////////////////////
+//  Core modifier functionality                           //
+////////////////////////////////////////////////////////////
+
+//  Remove all leftover keybinds
 unbindall
 
 bind "ALT" "+keyshift3"
 bind "SPACE" "+keyshift3"
 
-//Toggle Quick-Cast / Normal-Cast per item
+
+////////////////////////////////////////////////////////////
+//  Custom Binds                                          //
+////////////////////////////////////////////////////////////
+
+//  Toggle Quick-Cast / Normal-Cast per item
 bind "mouse5" "toggle_cast_type_item_0"
 bind "D" "toggle_cast_type_item_1"
 bind "F" "toggle_cast_type_item_2"
@@ -16,7 +25,7 @@ bind "X" "toggle_cast_type_item_3"
 bind "C" "toggle_cast_type_item_4"
 bind "V" "toggle_cast_type_item_5"
 
-//Toggle Quick-Cast / Normal-Cast per ability
+//  Toggle Quick-Cast / Normal-Cast per ability
 bind "Q" "toggle_cast_type_ability_0"
 bind "W" "toggle_cast_type_ability_1"
 bind "E" "toggle_cast_type_ability_2"

--- a/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_alt_space_pressed.cfg
+++ b/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_alt_space_pressed.cfg
@@ -1,0 +1,25 @@
+////////////////////////////////////////////////////////////////////////////
+//Alt + Space is pressed, shifting keyboard functions
+////////////////////////////////////////////////////////////////////////////
+
+//Remove all leftover keybinds
+unbindall
+
+bind "ALT" "+keyshift3"
+bind "SPACE" "+keyshift3"
+
+//Toggle Quick-Cast / Normal-Cast per item
+bind "mouse5" "toggle_cast_type_item_0"
+bind "D" "toggle_cast_type_item_1"
+bind "F" "toggle_cast_type_item_2"
+bind "X" "toggle_cast_type_item_3"
+bind "C" "toggle_cast_type_item_4"
+bind "V" "toggle_cast_type_item_5"
+
+//Toggle Quick-Cast / Normal-Cast per ability
+bind "Q" "toggle_cast_type_ability_0"
+bind "W" "toggle_cast_type_ability_1"
+bind "E" "toggle_cast_type_ability_2"
+bind "T" "toggle_cast_type_ability_3"
+bind "G" "toggle_cast_type_ability_4"
+bind "R" "toggle_cast_type_ability_5"

--- a/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_default.cfg
+++ b/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_default.cfg
@@ -1,23 +1,65 @@
 ////////////////////////////////////////////////////////////////////////////
-//Reverting to default keyboard commands
+//  Reverting to default keyboard commands                                //
 ////////////////////////////////////////////////////////////////////////////
 
-//Remove all leftover keybinds
+////////////////////////////////////////////////////////////
+//  Core modifier functionality                           //
+////////////////////////////////////////////////////////////
+
+//  Remove all leftover keybinds
 unbindall
 
-//Fix an issue with Chat Wheel
+//  Make SPACE be a modifier key
+bind "SPACE" "+keyShift"
+
+//  Make ALT be a modifier key
+bind "ALT" "+keyShift2"
+
+
+////////////////////////////////////////////////////////////
+//  Fixes                                                 //
+////////////////////////////////////////////////////////////
+
+//  Fix an issue with Chat Wheel
 -chatwheel
 
-//Fix an issue with Score Screen
+//  Fix an issue with Score Screen
 -showscores
 
-//Show the console
+
+////////////////////////////////////////////////////////////
+//  Binds                                                 //
+////////////////////////////////////////////////////////////
+
+//  Show the console
 bind "\" "toggleconsole"
 
-//Selecty hero
+//  Item Binds
+bind "mouse5" "enabled_use_item_0"
+bind "D" "enabled_use_item_1"
+bind "F" "enabled_use_item_2"
+bind "X" "enabled_use_item_3"
+bind "C" "enabled_use_item_4"
+bind "V" "enabled_use_item_5"
+
+//  Ability Binds
+bind "Q" "enabled_use_ability_0"
+bind "W" "enabled_use_ability_1"
+bind "E" "enabled_use_ability_2"
+bind "T" "enabled_use_ability_3"
+bind "G" "enabled_use_ability_4"
+bind "R" "enabled_use_ability_5"
+
+//  Select hero
 bind "1" +dota_camera_follow
 
-//The micromanagement section
+//  Go to recent event/ping
+bind "Z" "dota_recent_event;"
+
+//  Inspect hero
+bind "I" "inspectheroinworld"
+
+//  The micromanagement section
 bind "2" "+dota_control_group 1"
 bind "3" "+dota_control_group 2"
 bind "4" "+dota_control_group 3"
@@ -29,88 +71,35 @@ bind "9" "+dota_control_group 8"
 bind "0" "+dota_control_group 9"
 bind "TAB" "dota_cycle_selected"
 
-//Learn stats.
+//  Enter	the mode to learn an ability
+bind "Y" dota_ability_learn_mode
 bind "H" "dota_learn_stats"
 
-//Inspect hero
-bind "I" "inspectheroinworld"
-
-//Stop key
+//  Stop key
 bind "S" "dota_stop"
 
-//Camera movements
-bind "KP_2" "+back"
-bind "KP_4" "+moveleft"
-bind "KP_6" "+moveright"
-bind "KP_8" "+forward"
+//  A for attack move, instead of A + Click
+bind "A" "mc_attack"
 
-//Chat
+//  Shop
+bind "B" "toggleshoppanel"
+
+//  Enable/Disable right click deny when space isn't pressed, or when u is pressed
+rc_deny_space
+bind "u" "rc_deny_mode"
+
+//  Force right click deny on when o is pressed
+bind "o" "rc_deny_on"
+
+//  Chat
 bind "KP_ENTER" "say"
 bind "ENTER" "say"
 
-//Action items or taunts
-bind "[" "use_item_client player_loadout action_item"
-bind "]" "use_item_client current_hero taunt"
-
-//Function keys
-bind "F2" "dota_select_courier"
-bind "F3" "dota_courier_deliver"
-bind "F4" "dota_purchase_quickbuy"
-bind "F5" "gameui_activate"
-bind "F6" "dota_toggle_combatlog"
-bind "F8" "exec autoexec.cfg"
-bind "F9" "dota_pause"
-bind "F12" "jpeg"
-
-//Enter	 the mode to learn an ability
-bind "Y" dota_ability_learn_mode
-
-//Shop
-bind "B" "toggleshoppanel"
-
-//Voice chat
+//  Voice chat
 bind "CAPSLOCK" "+voicerecord"
 
-//Go to recent event/ping
-bind "Z" "dota_recent_event;"
-
-////////////////////////////////////////////////////////////
-//Custom Shit
-////////////////////////////////////////////////////////////
-
-//Make SPACE be a modifier key
-bind "SPACE" "+keyShift"
-
-//Make ALT be a modifier key
-bind "ALT" "+keyShift2"
-
-//Bind F7 as the quick/normal cast toggle switch
-bind "F7" "quick_normal_cast_toggle"
-
-//Mode toggled (Quick or Normal cast) cast for items
-bind "mouse5" "enabled_use_item_0"
-bind "D" "enabled_use_item_1"
-bind "F" "enabled_use_item_2"
-bind "X" "enabled_use_item_3"
-bind "C" "enabled_use_item_4"
-bind "V" "enabled_use_item_5"
-
-//Mode toggled (Quick or Normal cast) cast for abilities
-bind "Q" "enabled_use_ability_0"
-bind "W" "enabled_use_ability_1"
-bind "E" "enabled_use_ability_2"
-bind "T" "enabled_use_ability_3"
-bind "G" "enabled_use_ability_4"
-bind "R" "enabled_use_ability_5"
-
-//A for attack move, instead of A + Click
-bind "A" "mc_attack"
-
-// Shuffle camera to rune positions while pressing the keys and back to hero on release
-bind "F1" "+rune"
-
-//Missing Script and other communications
-//(binds the arrow keys to call missing, not as useful with the chat wheel thing but I prefer it still)
+//  Missing Script and other communications
+//  (binds the arrow keys to call missing, not as useful with the chat wheel thing but I prefer it still)
 bind "J" chatwheel_say 9 //Miss Top
 bind "K" chatwheel_say 10 //Miss Middle
 bind "L" chatwheel_say 11 //Miss Bot
@@ -118,28 +107,54 @@ bind "N" chatwheel_say 78 //I'm Back
 bind "M" chatwheel_say 29 //Enemy Returned
 bind "," chatwheel_say 30 //All Missing
 
-//Camera grip custom key
+//  Camera grip custom key
 bind "KP_5" "+cameraControl";
 
-//Toogle to enable disable auto select summoned units
+//  Camera movements
+bind "KP_2" "+back"
+bind "KP_4" "+moveleft"
+bind "KP_6" "+moveright"
+bind "KP_8" "+forward"
+
+//  Action items or taunts
+bind "[" "use_item_client player_loadout action_item"
+bind "]" "use_item_client current_hero taunt"
+
+
+////////////////////////////////////////////////////////////
+//  Function Keys                                         //
+////////////////////////////////////////////////////////////
+
+//  Shuffle camera to rune positions while pressing the keys and back to hero on release
+bind "F1" "+rune"
+
+bind "F2" "dota_select_courier"
+bind "F3" "dota_courier_deliver"
+bind "F4" "dota_purchase_quickbuy"
+bind "F5" "gameui_activate"
+bind "F6" "dota_toggle_combatlog"
+
+//  Bind F7 as the quick/normal cast toggle switch
+bind "F7" "quick_normal_cast_toggle"
+
+//  Reload Autoexec
+bind "F8" "exec autoexec.cfg"
+
+bind "F9" "dota_pause"
+
+//  Toggle to enable disable auto select summoned units
 bind "F10" "auto_select_summoned_toggle"
 
-// Bind F11 to enable/disable developer debug output
+//  Bind F11 to enable/disable developer debug output
 bind F11 "custom_toggle_developer"
 
+//  Take a screenshot
+bind "F12" "jpeg"
 
 
 ////////////////////////////////////////////////////////////
-//Custom Hero Mode binds
+//  Custom Hero Mode binds                                //
 ////////////////////////////////////////////////////////////
 
-//Load the hero binds for the hero toggled currently
+//  Load the hero binds for the hero toggled currently
 load_current_hero_nomod_binds
-
-
-// Enable/Disable right click deny when space isn't pressed, or when u is pressed
-rc_deny_space
-bind "u" "rc_deny_mode"
-
-// Force right click deny on when o is pressed
-bind "o" "rc_deny_on"

--- a/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_default.cfg
+++ b/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_default.cfg
@@ -88,23 +88,20 @@ bind "ALT" "+keyShift2"
 bind "F7" "quick_normal_cast_toggle"
 
 //Mode toggled (Quick or Normal cast) cast for items
-bind "mouse5" "toggle_enabled_use_item_0"
-bind "D" "toggle_enabled_use_item_1"
-bind "F" "toggle_enabled_use_item_2"
-bind "X" "toggle_enabled_use_item_3"
-bind "C" "toggle_enabled_use_item_4"
-bind "V" "toggle_enabled_use_item_5"
+bind "mouse5" "enabled_use_item_0"
+bind "D" "enabled_use_item_1"
+bind "F" "enabled_use_item_2"
+bind "X" "enabled_use_item_3"
+bind "C" "enabled_use_item_4"
+bind "V" "enabled_use_item_5"
 
 //Mode toggled (Quick or Normal cast) cast for abilities
-bind "Q" "toggle_enabled_use_ability_0"
-bind "W" "toggle_enabled_use_ability_1"
-bind "E" "toggle_enabled_use_ability_2"
-bind "T" "toggle_enabled_use_ability_3"
-bind "G" "toggle_enabled_use_ability_4"
-bind "R" "toggle_enabled_use_ability_5"
-
-//Load the primary cast mode keys for abilities and items
-load_primary_cast_mode
+bind "Q" "enabled_use_ability_0"
+bind "W" "enabled_use_ability_1"
+bind "E" "enabled_use_ability_2"
+bind "T" "enabled_use_ability_3"
+bind "G" "enabled_use_ability_4"
+bind "R" "enabled_use_ability_5"
 
 //A for attack move, instead of A + Click
 bind "A" "mc_attack"

--- a/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_space_pressed.cfg
+++ b/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_space_pressed.cfg
@@ -1,63 +1,29 @@
 ////////////////////////////////////////////////////////////////////////////
-//Spacebar is pressed, shifting keyboard functions
+//  Spacebar is pressed, shifting keyboard functions                      //
 ////////////////////////////////////////////////////////////////////////////
 
-//Remove all leftover keybinds
+////////////////////////////////////////////////////////////
+//  Core modifier functionality                           //
+////////////////////////////////////////////////////////////
+
+//  Remove all leftover keybinds
 unbindall
 
-//Show scoreboard
-bind "TAB" "+showscores"
-
-//Hold
-bind "S" "dota_hold"
-
-//Purchase sticky
-bind "B" "dota_purchase_stickybuy"
-
-//Enable chatwheel
-bind "CAPSLOCK" "+chatwheel"
-
-//Glyph key
-bind "F1" "dota_glyph"
-
-//Grab items from stash
-bind "F2" "stash_grab_all"
-
-//Courier speed burst
-bind "F3" "dota_courier_burst"
-
-
-////////////////////////////////////////////////////////////
-//Custom Shit
-////////////////////////////////////////////////////////////
-
-//Keep SPACE as the modifier
+//  Keep SPACE as the modifier
 bind "SPACE" "+keyShift"
 
-//Set ALT+SPACE to be a modifier
+//  Set ALT+SPACE to be a modifier
 bind "ALT" "+keyShift3"
 
-//SPACE+1 to jump camera to hero with single key
-bind "1" +tohero
+// Enable right click deny when space is pressed, and toggle mode is enabled
+rc_deny_space
 
-//SPACE+Key to jump camera to control group with single key
-bind "2" "+togroup1"
-bind "3" "+togroup2"
-bind "4" "+togroup3"
-bind "5" "+togroup4"
-bind "6" "+togroup5"
-bind "7" "+togroup6"
-bind "8" "+togroup7"
-bind "9" "+togroup8"
-bind "0" "+togroup9"
 
-//SPACE+A to move/follow
-bind "A" "mc_move"
+////////////////////////////////////////////////////////////
+//  Binds                                                 //
+////////////////////////////////////////////////////////////
 
-//UPGRADE COURIER (Good for those moments when the courier is one flying hit away from dying and you don't have time to browse the shop)
-bind "F4" "quick_upgrade_courier"
-
-//Mode toggled (Quick or Normal cast) cast for items
+//  Alternate cast mode for Items
 bind "mouse5" "alt_use_item_0"
 bind "D" "alt_use_item_1"
 bind "F" "alt_use_item_2"
@@ -65,7 +31,7 @@ bind "X" "alt_use_item_3"
 bind "C" "alt_use_item_4"
 bind "V" "alt_use_item_5"
 
-//Mode toggled (Quick or Normal cast) cast for abilities
+//  Alternate cast mode for Abilities
 bind "Q" "alt_use_ability_0"
 bind "W" "alt_use_ability_1"
 bind "E" "alt_use_ability_2"
@@ -73,11 +39,31 @@ bind "T" "alt_use_ability_3"
 bind "G" "alt_use_ability_4"
 bind "R" "alt_use_ability_5"
 
-//Toggle orb autocast
-//(one click button to toggle on every auto-cast ability, this works because no hero has more than 1 ability so it just tries to do it for all of them)
-bind "Z" "orb_toggle"
+//  Show scoreboard
+bind "TAB" "+showscores"
 
-//Binds to enable you to communicate with your team with your right side of the keyboard
+//  Hold
+bind "S" "dota_hold"
+
+//SPACE+A to move/follow
+bind "A" "mc_move"
+
+//  Purchase sticky
+bind "B" "dota_purchase_stickybuy"
+
+//  Enable chatwheel
+bind "CAPSLOCK" "+chatwheel"
+
+//  Glyph key
+bind "F1" "dota_glyph"
+
+//  Grab items from stash
+bind "F2" "stash_grab_all"
+
+//  Courier speed burst
+bind "F3" "dota_courier_burst"
+
+//  Binds to enable you to communicate with your team with your right side of the keyboard
 bind "U" chatwheel_say 51 //Stack
 bind "I" chatwheel_say 17 //Farm
 bind "O" chatwheel_say 15 //Group Up
@@ -89,14 +75,35 @@ bind "M" chatwheel_say 64 //Don't Give up
 bind "," chatwheel_say 70 //Relax
 
 
+////////////////////////////////////////////////////////////
+//  Scripts                                               //
+////////////////////////////////////////////////////////////
+
+//  SPACE+1 to jump camera to hero with single key
+bind "1" +tohero
+
+//  SPACE+Key to jump camera to control group with single key
+bind "2" "+togroup1"
+bind "3" "+togroup2"
+bind "4" "+togroup3"
+bind "5" "+togroup4"
+bind "6" "+togroup5"
+bind "7" "+togroup6"
+bind "8" "+togroup7"
+bind "9" "+togroup8"
+bind "0" "+togroup9"
+
+//  UPGRADE COURIER (Good for those moments when the courier is one flying hit away from dying and you don't have time to browse the shop)
+bind "F4" "quick_upgrade_courier"
+
+//  Toggle orb autocast
+//  (one click button to toggle on every auto-cast ability, this works because no hero has more than 1 ability so it just tries to do it for all of them)
+bind "Z" "orb_toggle"
+
 
 ////////////////////////////////////////////////////////////
-//Custom Hero Mode binds
+//  Custom Hero Mode binds                                //
 ////////////////////////////////////////////////////////////
 
-//Load the hero binds for the hero toggled currently
+//  Load the hero binds for the hero toggled currently
 load_current_hero_space_binds
-
-
-// Enable right click deny when space is pressed, and toggle mode is enabled
-rc_deny_space

--- a/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_space_pressed.cfg
+++ b/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_space_pressed.cfg
@@ -34,6 +34,9 @@ bind "F3" "dota_courier_burst"
 //Keep SPACE as the modifier
 bind "SPACE" "+keyShift"
 
+//Set ALT+SPACE to be a modifier
+bind "ALT" "+keyShift3"
+
 //SPACE+1 to jump camera to hero with single key
 bind "1" +tohero
 
@@ -51,27 +54,24 @@ bind "0" "+togroup9"
 //SPACE+A to move/follow
 bind "A" "mc_move"
 
-//Load the secondary cast mode keys for abilities and items
-load_secondary_cast_mode
-
 //UPGRADE COURIER (Good for those moments when the courier is one flying hit away from dying and you don't have time to browse the shop)
 bind "F4" "quick_upgrade_courier"
 
 //Mode toggled (Quick or Normal cast) cast for items
-bind "mouse5" "toggle_enabled_use_item_0"
-bind "D" "toggle_enabled_use_item_1"
-bind "F" "toggle_enabled_use_item_2"
-bind "X" "toggle_enabled_use_item_3"
-bind "C" "toggle_enabled_use_item_4"
-bind "V" "toggle_enabled_use_item_5"
+bind "mouse5" "alt_use_item_0"
+bind "D" "alt_use_item_1"
+bind "F" "alt_use_item_2"
+bind "X" "alt_use_item_3"
+bind "C" "alt_use_item_4"
+bind "V" "alt_use_item_5"
 
 //Mode toggled (Quick or Normal cast) cast for abilities
-bind "Q" "toggle_enabled_use_ability_0"
-bind "W" "toggle_enabled_use_ability_1"
-bind "E" "toggle_enabled_use_ability_2"
-bind "T" "toggle_enabled_use_ability_3"
-bind "G" "toggle_enabled_use_ability_4"
-bind "R" "toggle_enabled_use_ability_5"
+bind "Q" "alt_use_ability_0"
+bind "W" "alt_use_ability_1"
+bind "E" "alt_use_ability_2"
+bind "T" "alt_use_ability_3"
+bind "G" "alt_use_ability_4"
+bind "R" "alt_use_ability_5"
 
 //Toggle orb autocast
 //(one click button to toggle on every auto-cast ability, this works because no hero has more than 1 ability so it just tries to do it for all of them)

--- a/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_toggle_non-quickcast.cfg
+++ b/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_toggle_non-quickcast.cfg
@@ -1,9 +1,9 @@
-//THIS FILE SHOULDN'T BE MODIFIED
-//It's used for setting all casts to normal cast (for items/abilities) at the press of a button
+//  THIS FILE SHOULDN'T BE MODIFIED
+//  It's used for setting all casts to normal cast (for items/abilities) at the press of a button
 
 say_team "All Items and Abilities set to Normal Cast"
 
-//Normal cast alias for items
+//  Normal cast alias for items
 toggle_normal_cast_item_0
 toggle_normal_cast_item_1
 toggle_normal_cast_item_2
@@ -11,7 +11,7 @@ toggle_normal_cast_item_3
 toggle_normal_cast_item_4
 toggle_normal_cast_item_5
 
-//Normal cast alias for abilities
+//  Normal cast alias for abilities
 toggle_normal_cast_ability_0
 toggle_normal_cast_ability_1
 toggle_normal_cast_ability_2

--- a/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_toggle_non-quickcast.cfg
+++ b/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_toggle_non-quickcast.cfg
@@ -1,20 +1,20 @@
 //THIS FILE SHOULDN'T BE MODIFIED
-//It's used for switching Normal casts with Quick casts (for items/abilities) at the press of a button
+//It's used for setting all casts to normal cast (for items/abilities) at the press of a button
 
+say_team "All Items and Abilities set to Normal Cast"
 
 //Normal cast alias for items
-alias toggle_enabled_use_item_0 "dota_item_execute 0"	
-alias toggle_enabled_use_item_1 "dota_item_execute 1"
-alias toggle_enabled_use_item_2 "dota_item_execute 2"
-alias toggle_enabled_use_item_3 "dota_item_execute 3"
-alias toggle_enabled_use_item_4 "dota_item_execute 4"
-alias toggle_enabled_use_item_5 "dota_item_execute 5"
+toggle_normal_cast_item_0
+toggle_normal_cast_item_1
+toggle_normal_cast_item_2
+toggle_normal_cast_item_3
+toggle_normal_cast_item_4
+toggle_normal_cast_item_5
 
 //Normal cast alias for abilities
-alias toggle_enabled_use_ability_0 "dota_ability_execute 0"
-alias toggle_enabled_use_ability_1 "dota_ability_execute 1"
-alias toggle_enabled_use_ability_2 "dota_ability_execute 2"
-alias toggle_enabled_use_ability_3 "dota_ability_execute 3"
-alias toggle_enabled_use_ability_4 "dota_ability_execute 4"
-alias toggle_enabled_use_ability_5 "dota_ability_execute 5"
-
+toggle_normal_cast_ability_0
+toggle_normal_cast_ability_1
+toggle_normal_cast_ability_2
+toggle_normal_cast_ability_3
+toggle_normal_cast_ability_4
+toggle_normal_cast_ability_5

--- a/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_toggle_quickcast.cfg
+++ b/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_toggle_quickcast.cfg
@@ -1,9 +1,9 @@
-//THIS FILE SHOULDN'T BE MODIFIED
-//It's used for setting all casts to quickcasts (for items/abilities) at the press of a button
+//  THIS FILE SHOULDN'T BE MODIFIED
+//  It's used for setting all casts to quickcasts (for items/abilities) at the press of a button
 
 say_team "All Items and Abilities set to Quick-Cast"
 
-//Quick cast alias for items
+//  Quick cast alias for items
 toggle_quick_cast_ability_0
 toggle_quick_cast_ability_1
 toggle_quick_cast_ability_2
@@ -11,7 +11,7 @@ toggle_quick_cast_ability_3
 toggle_quick_cast_ability_4
 toggle_quick_cast_ability_5
 
-//Quick cast alias for abilities
+//  Quick cast alias for abilities
 toggle_quick_cast_item_0
 toggle_quick_cast_item_1
 toggle_quick_cast_item_2

--- a/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_toggle_quickcast.cfg
+++ b/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_toggle_quickcast.cfg
@@ -4,17 +4,17 @@
 say_team "All Items and Abilities set to Quick-Cast"
 
 //  Quick cast alias for items
-toggle_quick_cast_ability_0
-toggle_quick_cast_ability_1
-toggle_quick_cast_ability_2
-toggle_quick_cast_ability_3
-toggle_quick_cast_ability_4
-toggle_quick_cast_ability_5
-
-//  Quick cast alias for abilities
 toggle_quick_cast_item_0
 toggle_quick_cast_item_1
 toggle_quick_cast_item_2
 toggle_quick_cast_item_3
 toggle_quick_cast_item_4
 toggle_quick_cast_item_5
+
+//  Quick cast alias for abilities
+toggle_quick_cast_ability_0
+toggle_quick_cast_ability_1
+toggle_quick_cast_ability_2
+toggle_quick_cast_ability_3
+toggle_quick_cast_ability_4
+toggle_quick_cast_ability_5

--- a/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_toggle_quickcast.cfg
+++ b/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_toggle_quickcast.cfg
@@ -1,18 +1,20 @@
 //THIS FILE SHOULDN'T BE MODIFIED
-//It's used for switching Normal casts with Quick casts (for items/abilities) at the press of a button
+//It's used for setting all casts to quickcasts (for items/abilities) at the press of a button
+
+say_team "All Items and Abilities set to Quick-Cast"
 
 //Quick cast alias for items
-alias toggle_enabled_use_item_0 "dota_item_quick_cast 0"	
-alias toggle_enabled_use_item_1 "dota_item_quick_cast 1"
-alias toggle_enabled_use_item_2 "dota_item_quick_cast 2"
-alias toggle_enabled_use_item_3 "dota_item_quick_cast 3"
-alias toggle_enabled_use_item_4 "dota_item_quick_cast 4"
-alias toggle_enabled_use_item_5 "dota_item_quick_cast 5"
+toggle_quick_cast_ability_0
+toggle_quick_cast_ability_1
+toggle_quick_cast_ability_2
+toggle_quick_cast_ability_3
+toggle_quick_cast_ability_4
+toggle_quick_cast_ability_5
 
 //Quick cast alias for abilities
-alias toggle_enabled_use_ability_0 "dota_ability_quickcast 0"
-alias toggle_enabled_use_ability_1 "dota_ability_quickcast 1"
-alias toggle_enabled_use_ability_2 "dota_ability_quickcast 2"
-alias toggle_enabled_use_ability_3 "dota_ability_quickcast 3"
-alias toggle_enabled_use_ability_4 "dota_ability_quickcast 4"
-alias toggle_enabled_use_ability_5 "dota_ability_quickcast 5"
+toggle_quick_cast_item_0
+toggle_quick_cast_item_1
+toggle_quick_cast_item_2
+toggle_quick_cast_item_3
+toggle_quick_cast_item_4
+toggle_quick_cast_item_5

--- a/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_togglekeys.cfg
+++ b/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_togglekeys.cfg
@@ -1,0 +1,110 @@
+// THIS FILE SHOULDN'T BE MODIFIED
+// This allows for abilities and items to be individually toggled between normal and quick cast types.
+
+
+// Creates Aliases for quick-casts and normal casts for neater scripts, and more predictable behavior
+alias "quick_ability_0" "dota_ability_quickcast 0"
+alias "quick_ability_1" "dota_ability_quickcast 1"
+alias "quick_ability_2" "dota_ability_quickcast 2"
+alias "quick_ability_3" "dota_ability_quickcast 3"
+alias "quick_ability_4" "dota_ability_quickcast 4"
+alias "quick_ability_5" "dota_ability_quickcast 5"
+
+alias "normal_ability_0" "dota_ability_execute 0"
+alias "normal_ability_1" "dota_ability_execute 1"
+alias "normal_ability_2" "dota_ability_execute 2"
+alias "normal_ability_3" "dota_ability_execute 3"
+alias "normal_ability_4" "dota_ability_execute 4"
+alias "normal_ability_5" "dota_ability_execute 5"
+
+alias "quick_item_0" "dota_item_quick_cast 0"
+alias "quick_item_1" "dota_item_quick_cast 1"
+alias "quick_item_2" "dota_item_quick_cast 2"
+alias "quick_item_3" "dota_item_quick_cast 3"
+alias "quick_item_4" "dota_item_quick_cast 4"
+alias "quick_item_5" "dota_item_quick_cast 5"
+
+alias "normal_item_0" "dota_item_execute 0"
+alias "normal_item_1" "dota_item_execute 1"
+alias "normal_item_2" "dota_item_execute 2"
+alias "normal_item_3" "dota_item_execute 3"
+alias "normal_item_4" "dota_item_execute 4"
+alias "normal_item_5" "dota_item_execute 5"
+
+
+// Set default state of Ability toggles
+alias "enabled_use_ability_0" "quick_ability_0"
+alias "enabled_use_ability_1" "quick_ability_1"
+alias "enabled_use_ability_2" "quick_ability_2"
+alias "enabled_use_ability_3" "quick_ability_3"
+alias "enabled_use_ability_4" "quick_ability_4"
+alias "enabled_use_ability_5" "quick_ability_5"
+
+// Set default state of Item toggles
+alias "enabled_use_item_0" "quick_item_0"
+alias "enabled_use_item_1" "quick_item_1"
+alias "enabled_use_item_2" "quick_item_2"
+alias "enabled_use_item_3" "quick_item_3"
+alias "enabled_use_item_4" "quick_item_4"
+alias "enabled_use_item_5" "quick_item_5"
+
+// Set default state of Space+Ability toggles
+alias "alt_use_ability_0" "normal_ability_0"
+alias "alt_use_ability_1" "normal_ability_1"
+alias "alt_use_ability_2" "normal_ability_2"
+alias "alt_use_ability_3" "normal_ability_3"
+alias "alt_use_ability_4" "normal_ability_4"
+alias "alt_use_ability_5" "normal_ability_5"
+
+// Set default state of Space+Item toggles
+alias "alt_use_item_0" "normal_item_0"
+alias "alt_use_item_1" "normal_item_1"
+alias "alt_use_item_2" "normal_item_2"
+alias "alt_use_item_3" "normal_item_3"
+alias "alt_use_item_4" "normal_item_4"
+alias "alt_use_item_5" "normal_item_5"
+
+// Toggle Quick/Normal Cast Abilities
+alias "toggle_cast_type_ability_0" "toggle_normal_cast_ability_0"
+alias "toggle_cast_type_ability_1" "toggle_normal_cast_ability_1"
+alias "toggle_cast_type_ability_2" "toggle_normal_cast_ability_2"
+alias "toggle_cast_type_ability_3" "toggle_normal_cast_ability_3"
+alias "toggle_cast_type_ability_4" "toggle_normal_cast_ability_4"
+alias "toggle_cast_type_ability_5" "toggle_normal_cast_ability_5"
+
+alias "toggle_normal_cast_ability_0" "alias enabled_use_ability_0 normal_ability_0;alias alt_use_ability_0 quick_ability_0;alias toggle_cast_type_ability_0 toggle_quick_cast_ability_0;say_student Ability 1: Normal Cast"
+alias "toggle_normal_cast_ability_1" "alias enabled_use_ability_1 normal_ability_1;alias alt_use_ability_1 quick_ability_1;alias toggle_cast_type_ability_1 toggle_quick_cast_ability_1;say_student Ability 2: Normal Cast"
+alias "toggle_normal_cast_ability_2" "alias enabled_use_ability_2 normal_ability_2;alias alt_use_ability_2 quick_ability_2;alias toggle_cast_type_ability_2 toggle_quick_cast_ability_2;say_student Ability 3: Normal Cast"
+alias "toggle_normal_cast_ability_3" "alias enabled_use_ability_3 normal_ability_3;alias alt_use_ability_3 quick_ability_3;alias toggle_cast_type_ability_3 toggle_quick_cast_ability_3;say_student Sub Ability 1: Normal Cast"
+alias "toggle_normal_cast_ability_4" "alias enabled_use_ability_4 normal_ability_4;alias alt_use_ability_4 quick_ability_4;alias toggle_cast_type_ability_4 toggle_quick_cast_ability_4;say_student Sub Ability 2: Normal Cast"
+alias "toggle_normal_cast_ability_5" "alias enabled_use_ability_5 normal_ability_5;alias alt_use_ability_5 quick_ability_5;alias toggle_cast_type_ability_5 toggle_quick_cast_ability_5;say_student Ability Ultimate: Normal Cast"
+
+alias "toggle_quick_cast_ability_0" "alias enabled_use_ability_0 quick_ability_0;alias alt_use_ability_0 normal_ability_0;alias toggle_cast_type_ability_0 toggle_normal_cast_ability_0;say_student Ability 1: Quick Cast"
+alias "toggle_quick_cast_ability_1" "alias enabled_use_ability_1 quick_ability_1;alias alt_use_ability_1 normal_ability_1;alias toggle_cast_type_ability_1 toggle_normal_cast_ability_1;say_student Ability 2: Quick Cast"
+alias "toggle_quick_cast_ability_2" "alias enabled_use_ability_2 quick_ability_2;alias alt_use_ability_2 normal_ability_2;alias toggle_cast_type_ability_2 toggle_normal_cast_ability_2;say_student Ability 3: Quick Cast"
+alias "toggle_quick_cast_ability_3" "alias enabled_use_ability_3 quick_ability_3;alias alt_use_ability_3 normal_ability_3;alias toggle_cast_type_ability_3 toggle_normal_cast_ability_3;say_student Sub Ability 1: Quick Cast"
+alias "toggle_quick_cast_ability_4" "alias enabled_use_ability_4 quick_ability_4;alias alt_use_ability_4 normal_ability_4;alias toggle_cast_type_ability_4 toggle_normal_cast_ability_4;say_student Sub Ability 2: Quick Cast"
+alias "toggle_quick_cast_ability_5" "alias enabled_use_ability_5 quick_ability_5;alias alt_use_ability_5 normal_ability_5;alias toggle_cast_type_ability_5 toggle_normal_cast_ability_5;say_student Ability Ultimate: Quick Cast"
+
+
+// Toggle Quick/Normal Cast Items
+alias "toggle_cast_type_item_0" "toggle_normal_cast_item_0"
+alias "toggle_cast_type_item_1" "toggle_normal_cast_item_1"
+alias "toggle_cast_type_item_2" "toggle_normal_cast_item_2"
+alias "toggle_cast_type_item_3" "toggle_normal_cast_item_3"
+alias "toggle_cast_type_item_4" "toggle_normal_cast_item_4"
+alias "toggle_cast_type_item_5" "toggle_normal_cast_item_5"
+
+alias "toggle_normal_cast_item_0" "alias enabled_use_item_0 normal_item_0;alias alt_use_item_0 quick_item_0;alias toggle_cast_type_item_0 toggle_quick_cast_item_0;say_student Item 1: Normal Cast"
+alias "toggle_normal_cast_item_1" "alias enabled_use_item_1 normal_item_1;alias alt_use_item_1 quick_item_1;alias toggle_cast_type_item_1 toggle_quick_cast_item_1;say_student Item 2: Normal Cast"
+alias "toggle_normal_cast_item_2" "alias enabled_use_item_2 normal_item_2;alias alt_use_item_2 quick_item_2;alias toggle_cast_type_item_2 toggle_quick_cast_item_2;say_student Item 3: Normal Cast"
+alias "toggle_normal_cast_item_3" "alias enabled_use_item_3 normal_item_3;alias alt_use_item_3 quick_item_3;alias toggle_cast_type_item_3 toggle_quick_cast_item_3;say_student Item 4: Normal Cast"
+alias "toggle_normal_cast_item_4" "alias enabled_use_item_4 normal_item_4;alias alt_use_item_4 quick_item_4;alias toggle_cast_type_item_4 toggle_quick_cast_item_4;say_student Item 5: Normal Cast"
+alias "toggle_normal_cast_item_5" "alias enabled_use_item_5 normal_item_5;alias alt_use_item_5 quick_item_5;alias toggle_cast_type_item_5 toggle_quick_cast_item_5;say_student Item 6: Normal Cast"
+
+alias "toggle_quick_cast_item_0" "alias enabled_use_item_0 quick_item_0;alias alt_use_item_0 normal_item_0;alias toggle_cast_type_item_0 toggle_normal_cast_item_0;say_student Item 1: Quick Cast"
+alias "toggle_quick_cast_item_1" "alias enabled_use_item_1 quick_item_1;alias alt_use_item_1 normal_item_1;alias toggle_cast_type_item_1 toggle_normal_cast_item_1;say_student Item 2: Quick Cast"
+alias "toggle_quick_cast_item_2" "alias enabled_use_item_2 quick_item_2;alias alt_use_item 2 normal_item_2;alias toggle_cast_type_item_2 toggle_normal_cast_item_2;say_student Item 3: Quick Cast"
+alias "toggle_quick_cast_item_3" "alias enabled_use_item_3 quick_item_3;alias alt_use_item_3 normal_item_3;alias toggle_cast_type_item_3 toggle_normal_cast_item_3;say_student Item 4: Quick Cast"
+alias "toggle_quick_cast_item_4" "alias enabled_use_item_4 quick_item_4;alias alt_use_item_4 normal_item_4;alias toggle_cast_type_item_4 toggle_normal_cast_item_4;say_student Item 5: Quick Cast"
+alias "toggle_quick_cast_item_5" "alias enabled_use_item_5 quick_item_5;alias alt_use_item_5 normal_item_5;alias toggle_cast_type_item_5 toggle_normal_cast_item_5;say_student Item 6: Quick Cast"

--- a/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_togglekeys.cfg
+++ b/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_togglekeys.cfg
@@ -1,8 +1,7 @@
-// THIS FILE SHOULDN'T BE MODIFIED
-// This allows for abilities and items to be individually toggled between normal and quick cast types.
+//  THIS FILE SHOULDN'T BE MODIFIED
+//  This allows for abilities and items to be individually toggled between normal and quick cast types.
 
-
-// Creates Aliases for quick-casts and normal casts for neater scripts, and more predictable behavior
+//  Creates Aliases for quick-casts and normal casts for neater scripts, and more predictable behavior
 alias "quick_ability_0" "dota_ability_quickcast 0"
 alias "quick_ability_1" "dota_ability_quickcast 1"
 alias "quick_ability_2" "dota_ability_quickcast 2"
@@ -32,7 +31,7 @@ alias "normal_item_4" "dota_item_execute 4"
 alias "normal_item_5" "dota_item_execute 5"
 
 
-// Set default state of Ability toggles
+//  Set default state of Ability toggles
 alias "enabled_use_ability_0" "quick_ability_0"
 alias "enabled_use_ability_1" "quick_ability_1"
 alias "enabled_use_ability_2" "quick_ability_2"
@@ -40,7 +39,7 @@ alias "enabled_use_ability_3" "quick_ability_3"
 alias "enabled_use_ability_4" "quick_ability_4"
 alias "enabled_use_ability_5" "quick_ability_5"
 
-// Set default state of Item toggles
+//  Set default state of Item toggles
 alias "enabled_use_item_0" "quick_item_0"
 alias "enabled_use_item_1" "quick_item_1"
 alias "enabled_use_item_2" "quick_item_2"
@@ -48,7 +47,7 @@ alias "enabled_use_item_3" "quick_item_3"
 alias "enabled_use_item_4" "quick_item_4"
 alias "enabled_use_item_5" "quick_item_5"
 
-// Set default state of Space+Ability toggles
+//  Set default state of Space+Ability toggles
 alias "alt_use_ability_0" "normal_ability_0"
 alias "alt_use_ability_1" "normal_ability_1"
 alias "alt_use_ability_2" "normal_ability_2"
@@ -56,7 +55,7 @@ alias "alt_use_ability_3" "normal_ability_3"
 alias "alt_use_ability_4" "normal_ability_4"
 alias "alt_use_ability_5" "normal_ability_5"
 
-// Set default state of Space+Item toggles
+//  Set default state of Space+Item toggles
 alias "alt_use_item_0" "normal_item_0"
 alias "alt_use_item_1" "normal_item_1"
 alias "alt_use_item_2" "normal_item_2"
@@ -64,7 +63,7 @@ alias "alt_use_item_3" "normal_item_3"
 alias "alt_use_item_4" "normal_item_4"
 alias "alt_use_item_5" "normal_item_5"
 
-// Toggle Quick/Normal Cast Abilities
+//  Toggle Quick/Normal Cast Abilities
 alias "toggle_cast_type_ability_0" "toggle_normal_cast_ability_0"
 alias "toggle_cast_type_ability_1" "toggle_normal_cast_ability_1"
 alias "toggle_cast_type_ability_2" "toggle_normal_cast_ability_2"
@@ -87,7 +86,7 @@ alias "toggle_quick_cast_ability_4" "alias enabled_use_ability_4 quick_ability_4
 alias "toggle_quick_cast_ability_5" "alias enabled_use_ability_5 quick_ability_5;alias alt_use_ability_5 normal_ability_5;alias toggle_cast_type_ability_5 toggle_normal_cast_ability_5;say_student Ability Ultimate: Quick Cast"
 
 
-// Toggle Quick/Normal Cast Items
+//  Toggle Quick/Normal Cast Items
 alias "toggle_cast_type_item_0" "toggle_normal_cast_item_0"
 alias "toggle_cast_type_item_1" "toggle_normal_cast_item_1"
 alias "toggle_cast_type_item_2" "toggle_normal_cast_item_2"

--- a/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_settings_game.cfg
+++ b/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_settings_game.cfg
@@ -1,211 +1,205 @@
+////////////////////////////////////////////////////////////////////////////
+//  General Game Settings                                                 //
+////////////////////////////////////////////////////////////////////////////
 
-////////////////////////////////////////////////////////////
-//General Game Settings
-////////////////////////////////////////////////////////////
- 
-//Option to auto repeat right mouse
-dota_player_auto_repeat_right_mouse 1 
+//  Option to auto repeat right mouse
+dota_player_auto_repeat_right_mouse 1
 
-//Allow alt+right click to force movement in a direction.
+//  Allow alt+right click to force movement in a direction.
 dota_unit_allow_moveto_direction 1
 
-//Option to right click to deny creeps instead of A + Clicking
+//  Option to right click to deny creeps instead of A + Clicking
 dota_force_right_click_attack "1"
 
-//Flying units, like Firefly Batrider get raised by this height above ground
-dota_unit_fly_bonus_height "10" 
- 
-//Auto purchase items (off).
-dota_player_auto_purchase_items "0"     
+//  Flying units, like Firefly Batrider get raised by this height above ground
+dota_unit_fly_bonus_height "10"
 
-//Double tap ability self cast (NOTE: If you wish to re-enable it, you must also set a good tolerance like "dota_ability_self_cast_timeout 0.5")
-dota_ability_quick_cast "1"            
- 
-//Unified unit orders (on), using CTRL.
-dota_player_multipler_orders "1"        
+//  Auto purchase items (off).
+dota_player_auto_purchase_items "0"
 
-//Really bad option if enabled, can fuck up your TPs
-dota_reset_camera_on_spawn "0"
+//  Double tap ability self cast (NOTE: If you wish to re-enable it, you must also set a good tolerance like "dota_ability_self_cast_timeout 0.5")
+dota_ability_quick_cast "1"
 
-//Disables hero autoattack by default
-dota_player_units_auto_attack "0"
-dota_player_units_auto_attack_after_spell "0"  
- 
-//Auto add spawned summons to control group
-dota_player_add_summoned_to_selection "1" 
-
-//Shows spells are within casting range of targeted area/target with the help of an arrow
-dota_disable_range_finder 0         
-
-//Alt modifier + qwe/asd to be inv keys (off).
-dota_gamescom_althack "0"               
-
-//Lock mouse in the window mode (Window mode).
-dota_mouse_window_lock "1"              
-
-//Development Mode
-developer "0" 				
-
-
-
-////////////////////////////////////////////////////////////
-//Interface related
-////////////////////////////////////////////////////////////
-
-//Prevents you from double pressing to self cast (or makes it really fast so that it only happens with scripts)
+//  Prevents you from double pressing to self cast (or makes it really fast so that it only happens with scripts)
 dota_ability_self_cast_timeout 0.01
 
-//Change the item (tp scroll by default) placed in the sticky section of the quickbuy panel.
+//  Unified unit orders (on), using CTRL.
+dota_player_multipler_orders "1"
+
+//  Really bad option if enabled, can fuck up your TPs
+dota_reset_camera_on_spawn "0"
+
+//  Disables hero autoattack by default
+dota_player_units_auto_attack "0"
+dota_player_units_auto_attack_after_spell "0"
+
+//  Auto add spawned summons to control group
+dota_player_add_summoned_to_selection "1"
+
+//  Shows spells are within casting range of targeted area/target with the help of an arrow
+dota_disable_range_finder 0
+
+//  Alt modifier + qwe/asd to be inv keys (off).
+dota_gamescom_althack "0"
+
+//  Lock mouse in the window mode (Window mode).
+dota_mouse_window_lock "1"
+
+//  Development Mode
+developer "0"
+
+
+////////////////////////////////////////////////////////////
+//  Interface related                                     //
+////////////////////////////////////////////////////////////
+
+//  Change the item (tp scroll by default) placed in the sticky section of the quickbuy panel.
 hud_sticky_item_name "item_tpscroll"
 
-// show crit, gold, xp overhead
-dota_hud_show_overhead_events "1" 
+//  show crit, gold, xp overhead
+dota_hud_show_overhead_events "1"
 
-//Shows player names above heroes
+//  Shows player names above heroes
 dota_always_show_player_names "1"
 
-//Health is split up into sections (default=250)
+//  Health is split up into sections (default=250)
 dota_health_per_vertical_marker "200"
 
-//HP bars (Disables "0";No dividing blocks "1";Normal "3").
-dota_hud_healthbars "3"                 
+//  HP bars (Disables "0";No dividing blocks "1";Normal "3").
+dota_hud_healthbars "3"
 
-//Opacity major healthbar divider.
-dota_health_marker_major_alpha "255"    
+//  Opacity major healthbar divider.
+dota_health_marker_major_alpha "255"
 
-//Opacity minor healthbar divider.
-dota_health_marker_minor_alpha "128"    
+//  Opacity minor healthbar divider.
+dota_health_marker_minor_alpha "128"
 
-//Glowing of creeps HP bar.
-dota_hud_healthbar_hoveroutline_alpha "255"  
+//  Glowing of creeps HP bar.
+dota_hud_healthbar_hoveroutline_alpha "255"
 
-//Shop uses hotkeys when opened
+//  Shop uses hotkeys when opened
 dota_shop_force_hotkeys "1"
 
-//Fade time on DMG done/received
-//(I keep all of them to 0 to be instant and have the best feedback when I get )
-dota_health_hurt_decay_time_max "0"  
+//  Fade time on Damage done/received
+//  (I keep all of them to 0 to be instant and have the best feedback when I get )
+dota_health_hurt_decay_time_max "0"
 dota_health_hurt_decay_time_min "0"
 dota_health_hurt_delay "0"
 dota_pain_decay "0"
 dota_pain_factor "0"
 dota_pain_multiplier "0"
-dota_pain_fade_rate "0"   
+dota_pain_fade_rate "0"
 
-//Reverse camera grip 
+//  Reverse camera grip
 dota_camera_reverse "0"
 
-//Displays error msgs on hud (e.g. spell is on cool down)
-dota_sf_hud_error_msg "1"               
+//  Displays error messages on HUD (e.g. spell is on cool down)
+dota_sf_hud_error_msg "1"
 
-//Display time of Firstblood, killstreaks and multikills notifications.
-dota_sf_hud_header_display_time "3"     
+//  Display time of First-blood, kill-streaks and multi-kills notifications
+dota_sf_hud_header_display_time "3"
 
-//Shop view mode (default).
-dota_shop_view_mode "0"                 
+//  Shop view mode (default).
+dota_shop_view_mode "0"
 
-//Shop tree animation (off).
-dota_sf_hud_shop_tree_animtime "0"      
-
+//  Shop tree animation (off).
+dota_sf_hud_shop_tree_animtime "0"
 
 
 ////////////////////////////////////////////////////////////
-//Minimap related
+//  Minimap related                                       //
 ////////////////////////////////////////////////////////////
 
-//Changes the size of heroes on the minimap
-//(I like a high value so I can see their portrait flash on the minimap)
-dota_minimap_hero_size 1100  
+//  Changes the size of heroes on the minimap
+//  (I like a high value so I can see their portrait flash on the minimap)
+dota_minimap_hero_size 1100
 
-//Minimum time after the mouse enters the minimap before we accept a move command
+//  Minimum time after the mouse enters the minimap before we accept a move command
 dota_minimap_misclick_time "0"
 
-//Minimap icons instead of names
-dota_minimap_show_hero_icon "1" 
+//  Minimap icons instead of names
+dota_minimap_show_hero_icon "1"
 
-//Always draws the hero icons instead of the colored arrows/crosses (like having default ALT always pressed)
+//  Always draws the hero icons instead of the colored arrows/crosses (like having default ALT always pressed)
 dota_minimap_always_draw_hero_icons "1"
 
-//Hold alt to highligth hero
-dota_show_hero_finder "0" 
+//  Hold alt to highlight hero
+dota_show_hero_finder "0"
 
-//Minimap using simple colors
-dota_minimap_simple_colors "0"
+//  Minimap hide background
+dota_minimap_hide_background "0"
 
-//Minimap hide background 
-dota_minimap_hide_background "0"     
-
-//Distance from tower to iniate ping tower instead of ping map. 
+//  Distance from tower to initiate ping tower instead of ping map.
 dota_minimap_tower_defend_distance "150"
 
-//Duration of regular pings.
-dota_minimap_ping_duration "4"          
+//  Duration of regular pings.
+dota_minimap_ping_duration "4"
 
-//Duration of shield/attack pings on towers.
-dota_minimap_ping_tag_duration "4"      
+//  Duration of shield/attack pings on towers.
+dota_minimap_ping_tag_duration "4"
 
-//Shadow size for the hero name that is drawn on the map
-dota_minimap_hero_name_shadowsize "4"   
-                
-//Minimap colors for enemies, neutrals and friendlies (expressed in red/green/blue pairs) 
-dota_enemy_color_r "1"                                        
-dota_enemy_color_g "0"                  
-dota_enemy_color_b "0"                 
-dota_neutral_color_r "0"               
-dota_neutral_color_g "1"                
-dota_neutral_color_b "0"               
-dota_friendly_color_r "1"                 
-dota_friendly_color_g "1"               
-dota_friendly_color_b "1"               
+//  Shadow size for the hero name that is drawn on the map
+dota_minimap_hero_name_shadowsize "4"
 
+//  Minimap using simple colors
+dota_minimap_simple_colors "0"
 
- 
-////////////////////////////////////////////////////////////
-//Camera and shit
-////////////////////////////////////////////////////////////
- 
-//Camera move speed with edge pan
-//I like a high value, because I use mouse grip most of the time
-dota_camera_speed "10000"
+//  Minimap colors for enemies, neutrals and friendlies (expressed in red/green/blue pairs)
+dota_enemy_color_r "1"
+dota_enemy_color_g "0"
+dota_enemy_color_b "0"
+dota_neutral_color_r "0"
+dota_neutral_color_g "1"
+dota_neutral_color_b "0"
+dota_friendly_color_r "1"
+dota_friendly_color_g "1"
+dota_friendly_color_b "1"
 
-//Camera acceleration (50 = almost no acceleration)
-dota_camera_accelerate 50
-
-//Smoothing of camera.
-dota_camera_smooth_enable "0"           
-
-//Power of smoothing and other smoothing parameters
-dota_camera_smooth_count "0"            
-dota_camera_smooth_distance "96"        
- 
-//To disable the annoying camera zoom in with mouse wheel scroll
-dota_camera_disable_zoom "1"
-
-//Enables moving the camera by touching the edge of the screen with mouse
-dota_camera_edgemove "1" 
- 
-//Double tap to select and move the camera to your hero.
-dota_camera_follow_doublepress_time "0.5" 
-
-//Stops the screen shaking when certain spells are cast
-dota_screen_shake "0"
-
-//Enables edge shift when camera locked on hero
-dota_camera_lock_view_helper 0
-
-//Edge shift when camera locked on hero (default:220)
-dota_camera_lock_mouse_lead 700
-
-// Minimap icon scaling by heroes proximity to each other
-// When heroes are close together, their icons will be reduced in size on the minimap so that you can more easily see
-// who is there from the minimap. Without this, icons close together will overlap more and its hard to tell who is
-// there by looking at the minimap.
+//  Minimap icon scaling by heroes proximity to each other
+//  When heroes are close together, their icons will be reduced in size on the minimap so that you can more easily see
+//  who is there from the minimap. Without this, icons close together will overlap more and its hard to tell who is
+//  there by looking at the minimap.
 dota_minimap_hero_scalar 1
 
-// Proximity in pixels to begin scaling (default 12)
+//  Proximity in pixels to begin scaling (default 12)
 dota_minimap_hero_scalar_distance 20
- 
-// Minimum scaled size (default 500)
+
+//  Minimum scaled size (default 500)
 dota_minimap_hero_scalar_minimum 600
 
- 
+
+////////////////////////////////////////////////////////////
+//  Camera and shit                                       //
+////////////////////////////////////////////////////////////
+
+//  Camera move speed with edge pan
+//  I like a high value, because I use mouse grip most of the time
+dota_camera_speed "10000"
+
+//  Camera acceleration (50 = almost no acceleration)
+dota_camera_accelerate 50
+
+//  Smoothing of camera.
+dota_camera_smooth_enable "0"
+
+//  Power of smoothing and other smoothing parameters
+dota_camera_smooth_count "0"
+dota_camera_smooth_distance "96"
+
+//  To disable the annoying camera zoom in with mouse wheel scroll
+dota_camera_disable_zoom "1"
+
+//  Enables moving the camera by touching the edge of the screen with mouse
+dota_camera_edgemove "1"
+
+//  Double tap to select and move the camera to your hero.
+dota_camera_follow_doublepress_time "0.5"
+
+//  Stops the screen shaking when certain spells are cast
+dota_screen_shake "0"
+
+//  Enables edge shift when camera locked on hero
+dota_camera_lock_view_helper 0
+
+//  Edge shift when camera locked on hero (default:220)
+dota_camera_lock_mouse_lead 700

--- a/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_settings_tech.cfg
+++ b/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_settings_tech.cfg
@@ -1,64 +1,63 @@
-//NOTE: SOME OF THESE ARE NOT IN DOTA2 REBORN
+//  NOTE: SOME OF THESE ARE NOT IN DOTA2 REBORN
 
 ////////////////////////////////////////////////////////////
-//Graphics, Performance and shit
+//  Graphics, Performance and shit                        //
 ////////////////////////////////////////////////////////////
-fps_max "60"				//Forces client to a max FPS limit
-//NOT IN D2REBORN - mat_vsync "0"			
-//NOT IN D2REBORN - mat_triplebuffered "0"                  //Enable with vsync for a performance boost if fps is less than 60.
-dota_cheap_water 1                      //Crappy water, better performance
-cl_globallight_shadow_mode 0		//Shadow options
-r_deferred_height_fog 0			//Fog
-r_deferred_simple_light 1		//World Lighting
-r_deferred_additive_pass "0"            //Additive light pass  
-r_deferred_specular "0"                 //Specular 
-r_deferred_specular_bloom "0"           //Specular bloom 
-//NOT IN D2REBORN - r_screenspace_aa 0			//Anti-aliasing 
-r_ssao "0"                              //Ambient occlusion 
-//NOT IN D2REBORN - mat_picmip "0"                          //Textures quality (high).
-dota_embers "0" 			//turns off fire on mainmenu, less gpu/cpu load
-sv_forcepreload "1"			//Force server side preloading. 
-engine_no_focus_sleep "0"               //Reduces resources consumed when dota 2 loses focus.
-dota_portrait_animate "1"               //Hero portrait animations 
-dota_ambient_creatures "0"              //Ambient creatures 
+fps_max "60"                                     //  Forces client to a max FPS limit
+dota_cheap_water 1                               //  Crappy water, better performance
+cl_globallight_shadow_mode 0                     //  Shadow options
+r_deferred_height_fog 0                          //  Fog
+r_deferred_simple_light 1                        //  World Lighting
+r_deferred_additive_pass "0"                     //  Additive light pass
+r_deferred_specular "0"                          //  Specular
+r_deferred_specular_bloom "0"                    //  Specular bloom
+r_ssao "0"                                       //  Ambient occlusion
+dota_embers "0"                                  //  turns off fire on mainmenu, less gpu/cpu load
+sv_forcepreload "1"                              //  Force server side preloading
+engine_no_focus_sleep "0"                        //  Reduces resources consumed when dota 2 loses focus
+dota_portrait_animate "1"                        //  Hero portrait animations
+dota_ambient_creatures "0"                       //  Ambient creatures
+//  NOT IN D2REBORN - mat_vsync "0"
+//  NOT IN D2REBORN - mat_triplebuffered "0"     //  Enable with vsync for a performance boost if fps is less than 60
+//  NOT IN D2REBORN - r_screenspace_aa 0         //  Anti-aliasing
+//  NOT IN D2REBORN - mat_picmip "0"             //  Textures quality (high)
 
-//Some poeple got a fps boost enabling this one
-//r_fastzreject 1
+//  Some poeple got a fps boost enabling this one
+//  r_fastzreject 1
 
 
 ////////////////////////////////////////////////////////////
-//Netcode Shit
-//Altough the lerp value will probably blink red/yellowish in your netgraph, tests have shown that this is likely the most responsive setup possible.
+//  Netcode Shit
+//  Altough the lerp value will probably blink red/yellowish in your netgraph, tests have shown that this is likely the most responsive setup possible
 ////////////////////////////////////////////////////////////
- 
-cl_interp "0.033"                       // Interpolate object positions starting this many seconds in past                      (Default 0.055, Min 0.033)
-cl_interp_ratio "1"                     // Multiplies final result of cl_interp                                                 (Default 2)
-cl_smoothtime "0.01"                    // When errors occur smooth display over X time, 0 Disables                             (Default 0.1)
-rate "80000"                            // Total amount of bandwidth Dota 2 may use                                             (Default 80000)
-cl_updaterate "30"                      // Amount of updates recieved from server per second                                    (Default 30, Max 30)
-cl_cmdrate "30"                         // Amount of updates sent to server per second                                          (Default 30, Max 30)
+
+cl_interp "0.033"            //  Interpolate object positions starting this many seconds in past    (Default 0.055, Min 0.033)
+cl_interp_ratio "1"          //  Multiplies final result of cl_interp                               (Default 2)
+cl_smoothtime "0.01"         //  When errors occur smooth display over X time, 0 Disables           (Default 0.1)
+rate "80000"                 //  Total amount of bandwidth Dota 2 may use                           (Default 80000)
+cl_updaterate "30"           //  Amount of updates recieved from server per second                  (Default 30, Max 30)
+cl_cmdrate "30"              //  Amount of updates sent to server per second                        (Default 30, Max 30)
 cl_smooth "1"
 cl_lagcompensation "1"
 cl_pred_optimize "2"
- 
-//For netgraph display (netgraph properties)
-//NOT IN D2REBORN - net_graphinsetbottom "436"
-//NOT IN D2REBORN - net_graphinsetright "-68"
-//NOT IN D2REBORN - net_graphproportionalfont "0"
 
-//NOT IN D2REBORN - snd_updateaudiocache
- 
+//  For netgraph display (netgraph properties)
+//  NOT IN D2REBORN - net_graphinsetbottom "436"
+//  NOT IN D2REBORN - net_graphinsetright "-68"
+//  NOT IN D2REBORN - net_graphproportionalfont "0"
+
+//  NOT IN D2REBORN - snd_updateaudiocache
+
 
 ////////////////////////////////////////////////////////////
-//Multicore Support
-//Recommended only if you're running multi-core
+//  Multicore Support                                     //
+//  Recommended only if you're running multi-core         //
 ////////////////////////////////////////////////////////////
-//r_threaded_shadow_clip 1
-//r_queued_decals 1
-//r_queued_post_processing 1
-//mat_queue_mode 2			//Quad core rendering.
-//cl_threaded_bone_setup 1
-//cl_threaded_init 1
-//snd_mix_async "1"                     //Multicore sound rendering
 
- 
+//  r_threaded_shadow_clip 1
+//  r_queued_decals 1
+//  r_queued_post_processing 1
+//  mat_queue_mode 2			         //Quad core rendering.
+//  cl_threaded_bone_setup 1
+//  cl_threaded_init 1
+//  snd_mix_async "1"              //Multicore sound rendering

--- a/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_settings_tech.cfg
+++ b/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_settings_tech.cfg
@@ -3,6 +3,7 @@
 ////////////////////////////////////////////////////////////
 //  Graphics, Performance and shit                        //
 ////////////////////////////////////////////////////////////
+
 fps_max "60"                                     //  Forces client to a max FPS limit
 dota_cheap_water 1                               //  Crappy water, better performance
 cl_globallight_shadow_mode 0                     //  Shadow options
@@ -17,6 +18,7 @@ sv_forcepreload "1"                              //  Force server side preloadin
 engine_no_focus_sleep "0"                        //  Reduces resources consumed when dota 2 loses focus
 dota_portrait_animate "1"                        //  Hero portrait animations
 dota_ambient_creatures "0"                       //  Ambient creatures
+
 //  NOT IN D2REBORN - mat_vsync "0"
 //  NOT IN D2REBORN - mat_triplebuffered "0"     //  Enable with vsync for a performance boost if fps is less than 60
 //  NOT IN D2REBORN - r_screenspace_aa 0         //  Anti-aliasing


### PR DESCRIPTION
As per Issue #52, #26;

Using Alt+Space, and an ability / item key, that ability / item is toggled from quick-cast to normal-cast and back individually. "F7" will force all abilities and items to either quick-cast or normal-cast
depending on how many times it is pressed.

Excuse the potentially excessive binds in the additional file. I was having a problem with it and wanted to neaten the long scripts to be a little bit more readable. It works as-is, and I'm happier to leave it, though if someone wants to shorten it, go ahead.

NOTE: When Alt+Space is pressed, both keys have to be released before
either Alt or Space can be used as modifiers again.