### PR TITLE
Added support for Smart-Cast

### DIFF
--- a/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_functions_active.cfg
+++ b/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_functions_active.cfg
@@ -56,7 +56,7 @@ alias "openmic" "voice_vox 1; playsound sounds/ui/tutorial_ui_ding_01.vsnd_c; al
 alias "closemic" "voice_vox 0; playsound sounds/ui/ui_upgrade_ability_01.vsnd_c; alias mic_toggle openmic; say_student Open mic disabled"
 
 //  Toggle health segmentation between these values
-//alias "toggle_segments" "toggle dota_health_per_vertical_marker 200 300 400 500; playsound sounds/ui/ui_upgrade_ability_01.vsnd_c"
+//  alias "toggle_segments" "toggle dota_health_per_vertical_marker 200 300 400 500; playsound sounds/ui/ui_upgrade_ability_01.vsnd_c"
 alias "toggle_segments" "segment200"
 alias "segment200" "dota_health_per_vertical_marker 200; alias toggle_segments segment300; playsound sounds/ui/ui_upgrade_ability_01.vsnd_c"
 alias "segment300" "dota_health_per_vertical_marker 300; alias toggle_segments segment400; playsound sounds/ui/ui_upgrade_ability_01.vsnd_c"
@@ -135,3 +135,6 @@ alias "orb_toggle" "dota_ability_autocast 0; dota_ability_autocast 1; dota_abili
 //  Camera grip custom key
 alias "+cameraControl" "+cameragrip;+sixense_left_click";
 alias "-cameraControl" "-cameragrip;-sixense_left_click";
+
+//  Nothing alias
+alias "null" "echo  "

--- a/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_functions_active.cfg
+++ b/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_functions_active.cfg
@@ -76,6 +76,9 @@ alias "developer_off" "developer 0; alias custom_toggle_developer developer_on; 
 //  Individual Ability/Skill Quick/Normal Cast Toggle config
 exec dota2_gameplay_mode/dota2_keybinds_togglekeys.cfg
 
+//  Smart-cast aliases
+exec dota2_gameplay_mode/dota2_keybinds_smartcast_aliases.cfg
+
 //  Change between right-click deny on, off, space toggled
 alias "rc_deny_mode" "rc_deny_toggle"
 alias "rc_deny_space" "rc_deny_on"

--- a/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_alt_pressed.cfg
+++ b/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_alt_pressed.cfg
@@ -15,6 +15,9 @@ bind "ALT" "+keyShift2"
 //  Set ALT+SPACE to be a modifier
 bind "SPACE" "+keyShift3"
 
+//  Cancel any pending smart-cast actions
+smart_cancel
+
 
 ////////////////////////////////////////////////////////////
 //  Custom Binds                                          //

--- a/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_alt_space_pressed.cfg
+++ b/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_alt_space_pressed.cfg
@@ -12,6 +12,9 @@ unbindall
 bind "ALT" "+keyshift3"
 bind "SPACE" "+keyshift3"
 
+//  Cancel any pending smart-cast actions
+smart_cancel
+
 
 ////////////////////////////////////////////////////////////
 //  Custom Binds                                          //

--- a/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_default.cfg
+++ b/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_default.cfg
@@ -15,6 +15,9 @@ bind "SPACE" "+keyShift"
 //  Make ALT be a modifier key
 bind "ALT" "+keyShift2"
 
+//  Cancel pending Smart-cast actions
+smart_cancel
+
 
 ////////////////////////////////////////////////////////////
 //  Fixes                                                 //

--- a/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_smartcast_aliases.cfg
+++ b/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_smartcast_aliases.cfg
@@ -1,0 +1,35 @@
+//  THIS FILE SHOULDN'T BE MODIFIED
+//  This specifies how smart-casting will work
+
+//  Smartcast Ability Aliases
+alias "+smart_ability_0" "normal_ability_0; alias -smart_ability_0 quick_ability_0"
+alias "+smart_ability_1" "normal_ability_1; alias -smart_ability_1 quick_ability_1"
+alias "+smart_ability_2" "normal_ability_2; alias -smart_ability_2 quick_ability_2"
+alias "+smart_ability_3" "normal_ability_3; alias -smart_ability_3 quick_ability_3"
+alias "+smart_ability_4" "normal_ability_4; alias -smart_ability_4 quick_ability_4"
+alias "+smart_ability_5" "normal_ability_5; alias -smart_ability_5 quick_ability_5"
+
+alias "-smart_ability_0" "quick_ability_0"
+alias "-smart_ability_1" "quick_ability_1"
+alias "-smart_ability_2" "quick_ability_2"
+alias "-smart_ability_3" "quick_ability_3"
+alias "-smart_ability_4" "quick_ability_4"
+alias "-smart_ability_5" "quick_ability_5"
+
+//  Smartcast Item Aliases
+alias "+smart_item_0" "normal_item_0; alias -smart_item_0 quick_item_0"
+alias "+smart_item_1" "normal_item_1; alias -smart_item_1 quick_item_1"
+alias "+smart_item_2" "normal_item_2; alias -smart_item_2 quick_item_2"
+alias "+smart_item_3" "normal_item_3; alias -smart_item_3 quick_item_3"
+alias "+smart_item_4" "normal_item_4; alias -smart_item_4 quick_item_4"
+alias "+smart_item_5" "normal_item_5; alias -smart_item_5 quick_item_5"
+
+alias "-smart_item_0" "quick_item_0"
+alias "-smart_item_1" "quick_item_1"
+alias "-smart_item_2" "quick_item_2"
+alias "-smart_item_3" "quick_item_3"
+alias "-smart_item_4" "quick_item_4"
+alias "-smart_item_5" "quick_item_5"
+
+//  Smartcast Cancel (One long line)
+alias "smart_cancel" "alias -smart_item_0 null; alias -smart_item_1 null; alias -smart_item_2 null; alias -smart_item_3 null; alias -smart_item_4 null; alias -smart_item_5 null; alias -smart_ability_0 null; alias -smart_ability_1 null; alias -smart_ability_2 null; alias -smart_ability_3 null; alias -smart_ability_4 null; alias -smart_ability_5 null"

--- a/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_space_pressed.cfg
+++ b/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_space_pressed.cfg
@@ -15,8 +15,11 @@ bind "SPACE" "+keyShift"
 //  Set ALT+SPACE to be a modifier
 bind "ALT" "+keyShift3"
 
-// Enable right click deny when space is pressed, and toggle mode is enabled
+//  Enable right click deny when space is pressed, and toggle mode is enabled
 rc_deny_space
+
+//  Cancel any pending smart-cast actions
+smart_cancel
 
 
 ////////////////////////////////////////////////////////////


### PR DESCRIPTION
The aliases needed for smart-cast to work have been implemented, using any change in the modifier keys to cancel the smart-cast action. It has not been added to any of the bind toggles as of yet, however they can be used by people who want to bind it themselves using the "smart_ability_x" and "smart_item_x" aliases.