### PR TITLE
Fix alt-pressed selfcast abilities and items

### DIFF
--- a/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_alt_pressed.cfg
+++ b/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_alt_pressed.cfg
@@ -24,20 +24,20 @@ smart_cancel
 ////////////////////////////////////////////////////////////
 
 //  ALT to self cast for items
-bind "mouse5" "self_ability_0"
-bind "D" "self_ability_1"
-bind "F" "self_ability_2"
-bind "X" "self_ability_3"
-bind "C" "self_ability_4"
-bind "V" "self_ability_5"
+bind "mouse5" "self_item_0"
+bind "D" "self_item_1"
+bind "F" "self_item_2"
+bind "X" "self_item_3"
+bind "C" "self_item_4"
+bind "V" "self_item_5"
 
 //  ALT to self cast for abilities
-bind "Q" "self_item_0"
-bind "W" "self_item_1"
-bind "E" "self_item_2"
-bind "T" "self_item_3"
-bind "G" "self_item_4"
-bind "R" "self_item_5"
+bind "Q" "self_ability_0"
+bind "W" "self_ability_1"
+bind "E" "self_ability_2"
+bind "T" "self_ability_3"
+bind "G" "self_ability_4"
+bind "R" "self_ability_5"
 
 //  Auto-attack toggle (Custom command)
 bind "S" "auto_attack_toggle"


### PR DESCRIPTION
For some reason selfcast was inversed - qwertg was used for items and dfxcv for abilities. I suppose it's a bug.