### PR TITLE
Fix broken function file reference from #88.

### DIFF
--- a/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/autoexec.cfg
+++ b/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/autoexec.cfg
@@ -28,7 +28,7 @@ exec dota2_gameplay_mode/dota2_settings_game.cfg
 ////////////////////////////////////////////////////////////
 
 //  Sets up the active functions defined from the external file
-exec dota2_gameplay_mode/dota2_functions_active.cfg
+exec dota2_gameplay_mode/aliases/dota2_functions_active.cfg
 
 
 ////////////////////////////////////////////////////////////


### PR DESCRIPTION
@Sembrani's pull request reverted a change to `autoexec.cfg` which executed the new path to the main functions file. Looks like someone didn't double-check their directory layout! :-P.

Anyway, this fixes that regression.

(Would've called the branch `fix-function-file-regression`, but the alliteration was just too tempting...)