### PR TITLE
Reenable forced directional movement.

### DIFF
--- a/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_settings_game.cfg
+++ b/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_settings_game.cfg
@@ -6,7 +6,7 @@
 dota_player_auto_repeat_right_mouse 1
 
 //  Allow alt+right click to force movement in a direction.
-dota_unit_allow_moveto_direction 1
+cl_dota_alt_unit_movetodirection 1
 
 //  Flying units, like Firefly Batrider get raised by this height above ground
 dota_unit_fly_bonus_height "10"


### PR DESCRIPTION
Fix #96.

The script is based on a modified version of Thth's method from
https://www.reddit.com/r/DotA2/comments/3qra69/dota_2_update_main_client_october_29_2015_analysis/cwhnki7
split up over multiple files.

It keeps forced movement mapped to "`". Please note that this means hero
highlight and minimap icon mode switching on press do not work any more.