### PR TITLE
[Bug] Echo no longer a valid command.

### DIFF
--- a/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/aliases/dota2_functions_active.cfg
+++ b/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/aliases/dota2_functions_active.cfg
@@ -142,4 +142,4 @@ alias "+cameraControl" "+cameragrip;+sixense_left_click";
 alias "-cameraControl" "-cameragrip;-sixense_left_click";
 
 //  Nothing alias
-alias "null" "echo  "
+alias "null" " "


### PR DESCRIPTION
Fairly self explanatory. The echo command is no longer valid. It appears that a space adequately suppresses the error, but I am open to suggestions.