### PR TITLE
Fix quick_upgrade_courier (closes #119)

### DIFF
--- a/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/aliases/dota2_functions_active.cfg
+++ b/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/aliases/dota2_functions_active.cfg
@@ -91,7 +91,7 @@ alias "rc_deny_switch" "toggle dota_force_right_click_attack"
 ////////////////////////////////////////////////////////////
 
 //  UPGRADE COURIER (Good for those moments when the courier is one flying hit away from dying and you don't have time to browse the shop)
-alias "quick_upgrade_courier" "dota_shop_force_hotkeys 1;toggleshoppanel;shop_nav_to_tab 0;shop_select_itemrow 9;toggleshoppanel"
+alias "quick_upgrade_courier" "dota_shop_force_hotkeys 1;toggleshoppanel;shop_nav_to_tab 0;shop_select_itemrow 10;toggleshoppanel"
 
 //  A faster courier deliver items (just like the normal one, but it solves a bug that the one from volvo has), with team say
 //  solves this problem: http://www.twitch.tv/2c2c/b/564756824


### PR DESCRIPTION
Fix `quick_upgrade_courier` to actually upgrade the courier instead of purchasing a new walking courier.