### PR TITLE
Prevent unintentionally broadcasting help messages to team.

### DIFF
--- a/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/aliases/dota2_keybinds_toggle_non-quickcast.cfg
+++ b/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/aliases/dota2_keybinds_toggle_non-quickcast.cfg
@@ -1,7 +1,7 @@
 //  THIS FILE SHOULDN'T BE MODIFIED
 //  It's used for setting all casts to normal cast (for items/abilities) at the press of a button
 
-say_team "All Items and Abilities set to Normal Cast"
+say_student "All Items and Abilities set to Normal Cast"
 
 //  Normal cast alias for items
 toggle_normal_cast_item_0

--- a/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/aliases/dota2_keybinds_toggle_quickcast.cfg
+++ b/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/aliases/dota2_keybinds_toggle_quickcast.cfg
@@ -1,7 +1,7 @@
 //  THIS FILE SHOULDN'T BE MODIFIED
 //  It's used for setting all casts to quickcasts (for items/abilities) at the press of a button
 
-say_team "All Items and Abilities set to Quick-Cast"
+say_student "All Items and Abilities set to Quick-Cast"
 
 //  Quick cast alias for items
 toggle_quick_cast_item_0


### PR DESCRIPTION
Prevent broadcasting "All Items and Abilities set to Quick-Cast/Normal
Cast" to your entire team when using F7 to toggle between quick cast and
normal cast. Closes issue #121.