### PR TITLE
Remove sixense

### DIFF
--- a/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/aliases/dota2_functions_active.cfg
+++ b/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/aliases/dota2_functions_active.cfg
@@ -136,7 +136,3 @@ alias "bottom_rune" "dota_camera_set_lookatpos 2824.360596 -2323.923096; alias +
 //  Toggle orb autocast
 //  (one click button to toggle on every auto-cast ability, this works because no hero has more than 1 ability so it just tries to do it for all of them)
 alias "orb_toggle" "dota_ability_autocast 0; dota_ability_autocast 1; dota_ability_autocast 2; dota_ability_autocast 3; dota_ability_autocast 4;dota_ability_autocast 5"
-
-//  Camera grip custom key (Not working in Reborn)
-alias "+cameraControl" "+cameragrip;+sixense_left_click";
-alias "-cameraControl" "-cameragrip;-sixense_left_click";

--- a/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_default.cfg
+++ b/Dota 2 Reborn Keyboard Setups/Loopuleasa's Super Compact QWERTG-DFXCV layout (ALT,SPACE mods)/dota2_gameplay_mode/dota2_keybinds_default.cfg
@@ -110,14 +110,12 @@ bind "N" chatwheel_say 78 //I'm Back
 bind "M" chatwheel_say 29 //Enemy Returned
 bind "," chatwheel_say 30 //All Missing
 
-//  Camera grip custom key
-bind "KP_5" "+cameraControl";
-
 //  Camera movements
 bind "KP_2" "+back"
 bind "KP_4" "+moveleft"
 bind "KP_6" "+moveright"
 bind "KP_8" "+forward"
+bind "mouse3" "+cameragrip"
 
 //  Action items or taunts
 bind "[" "use_item_client player_loadout action_item"


### PR DESCRIPTION
This is not a command in dota, and it doesn't seem to do anything
different from just using `+cameragrip`.

It just throws warnings on linux, as that hasn't been implemented.